### PR TITLE
Bump HDF5.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ QUBOTools_MOI = ["MathOptInterface"]
 [compat]
 GeometryBasics            = "0.4"
 Graphs                    = "1"
-HDF5                      = "0.16.15"
+HDF5                      = "0.17.2"
 JSON                      = "0.21.3"
 JSONSchema                = "1"
 MathOptInterface          = "1"


### PR DESCRIPTION
The project is fully compatible with the current HDF5.jl versions (0.17.x). It would be beneficial to update the dependencies accordingly, as this change would streamline the management of external projects that rely on both QUBOTools.jl and the latest HDF5.jl features.