### PR TITLE
Allow GeometryBasics 0.5 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Allow GeometryBasics 0.5 so downstream packages can resolve newer SciML stacks alongside QUBOTools.
 
+### Documentation
+
+- Update the manual introduction link to the canonical JuliaQUBO repository.
+
 ## v0.12.0 (2026-05-21)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # QUBOTools.jl Changelog
 
+## Unreleased
+
+### Compatibility
+
+- Allow GeometryBasics 0.5 so downstream packages can resolve newer SciML stacks alongside QUBOTools.
+
 ## v0.12.0 (2026-05-21)
 
 ### Breaking Changes

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ QUBOTools_MOI = ["MathOptInterface"]
 
 [compat]
 Dates                     = "1"
-GeometryBasics            = "0.4"
+GeometryBasics            = "0.4, 0.5"
 Graphs                    = "1"
 HDF5                      = "0.17.2"
 JSON                      = "0.21.3"

--- a/docs/src/manual/1-start.md
+++ b/docs/src/manual/1-start.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This manual aims to explain the fundamental concepts behind loading, manipulating and analyzing models with [QUBOTools](https://github.com/psrenergy/QUBOTools.jl).
+This manual aims to explain the fundamental concepts behind loading, manipulating and analyzing models with [QUBOTools](https://github.com/JuliaQUBO/QUBOTools.jl).
 
 ## Table of Contents
 

--- a/test/integration/docs.jl
+++ b/test/integration/docs.jl
@@ -18,6 +18,13 @@ function test_docs()
         index_html = read(index_path, String)
         @test occursin("https://github.com/JuliaQUBO/QUBOTools.jl/blob/main/docs/src/index.md", index_html)
         @test !occursin("https://github.com/JuliaQUBO/QUBOTools.jl/blob/master/", index_html)
+
+        manual_start_path = joinpath(__DOCS_PATH__, "build", "manual", "1-start", "index.html")
+        @test isfile(manual_start_path)
+
+        manual_start_html = read(manual_start_path, String)
+        @test occursin("https://github.com/JuliaQUBO/QUBOTools.jl", manual_start_html)
+        @test !occursin("https://github.com/psrenergy/QUBOTools.jl", manual_start_html)
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- Allow `GeometryBasics` 0.5 in addition to the existing 0.4 compatibility.
- Update the remaining legacy `psrenergy` documentation link to the canonical JuliaQUBO repository.
- Add a documentation integration assertion to keep the generated manual from reintroducing the legacy repository URL.

## Root Cause

`QUBODrivers` 0.5 correctly allows `QUBOTools` 0.12, but `QUBOTools` 0.12 currently restricts `GeometryBasics` to 0.4. That keeps `StructArrays` on 0.6, and when a downstream environment also includes `QuantumAnnealing` 0.2 it causes the resolver to select an older SciML combination:

- `LinearSolve` 3.28.0
- `OrdinaryDiffEqCore` 2.3.0
- `OrdinaryDiffEqDifferentiation` 1.19.0

That stack fails downstream with `UndefVarError: LinearVerbosity not defined`.

Allowing `GeometryBasics` 0.5 lets the resolver select `GeometryBasics` 0.5.10 and avoid the `StructArrays` 0.6 constraint, while keeping compatibility with the previously allowed 0.4 line.

Issue #77 identified one remaining legacy PSR repository link in the manual introduction; the docs source now points at `https://github.com/JuliaQUBO/QUBOTools.jl`.

## Validation

Tested locally:

```text
git diff --check origin/main...HEAD
```

Result: passed.

```text
JULIA_DEPOT_PATH=/home/bernalde/repos/QUBOTools.jl/.julia-depot julia --project=. -e 'using Pkg; Pkg.test(; coverage=false)'
```

Result on Julia 1.10.11 from a clean detached worktree: passed, 655/655 tests. The test environment resolved `GeometryBasics` 0.5.10.

```text
JULIA_DEPOT_PATH=/home/bernalde/repos/QUBOTools.jl/.julia-depot julia +1.12 --project=. -e 'using Pkg; Pkg.test(; coverage=false)'
```

Result on Julia 1.12.6 from the local worktree: passed, 655/655 tests.

Earlier benchmark harness validation on this branch:

```text
JULIA_DEPOT_PATH=/home/bernalde/repos/QUBOTools.jl/.julia-depot julia --project=benchmark benchmark/test/runtests.jl
```

Result: passed, 17/17 benchmark harness tests.

Downstream resolver probe using this branch:

```julia
using Pkg
Pkg.activate(; temp = true)
Pkg.develop(PackageSpec(path = "/tmp/QUBOTools-pr"))
Pkg.add([
    PackageSpec(name = "QuantumAnnealing", version = "0.2"),
    PackageSpec(name = "QUBODrivers", version = "0.5"),
])
```

Resulting relevant stack:

```text
QUBODrivers                       0.5.0
QUBOTools                         0.12.0
QuantumAnnealing                  0.2.0
DifferentialEquations             7.17.0
LinearSolve                       3.82.0
OrdinaryDiffEq                    6.111.0
OrdinaryDiffEqCore                3.33.1
OrdinaryDiffEqDifferentiation     2.9.0
SciMLBase                         2.155.1
GeometryBasics                    0.5.10
RecursiveArrayTools               3.54.0
```

## Notes

`QUBODrivers` does not appear to need a compatibility change for this resolver issue: 0.5 already allows `QUBOTools` 0.12.

Related downstream work: JuliaQUBO/QuantumAnnealingInterface.jl#4.

Closes #77.
