### PR TITLE
Add Dependabot dependency maintenance config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/benchmark"
+    schedule:
+      interval: "weekly"
+    groups:
+      benchmark-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/test"
+    schedule:
+      interval: "weekly"
+    groups:
+      test-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/test/integration/integration.jl
+++ b/test/integration/integration.jl
@@ -4,7 +4,7 @@ include("docs.jl")
 function test_foreign()
     if run_foreign_tests()
         @testset "▶ Foreign Package Tests" verbose = true begin
-            test_foreign_pkg(Pkg.PackageSpec(name="ToQUBO", rev="master"))
+            test_foreign_pkg(Pkg.PackageSpec(name="ToQUBO", rev="main"))
             test_foreign_pkg("QUBODrivers")
             test_foreign_pkg("QUBO")
         end


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` instead of a CompatHelper workflow, matching the finalized JuliaQUBO dependency maintenance policy.
- Enables weekly grouped Julia dependency updates for the root package plus `docs`, `benchmark`, and `test`, because each environment maintains its own `[compat]` bounds.
- Enables monthly `github-actions` updates for workflow action pins.

## Permissions and secrets

This repository depends on the public Julia General registry, so no CompatHelper workflow, PAT, or dedicated repository secret is required. Dependabot PRs should run the repository's normal CI and documentation checks before merging. Per the ecosystem policy, repositories that require custom or private registries should keep CompatHelper until Dependabot supports that use case.

## Tests

- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort "bad version" unless data["version"] == 2; updates = data["updates"]; abort "bad updates" unless updates.is_a?(Array) && updates.size == 5; puts updates.map { |u| "#{u["package-ecosystem"]}:#{u["directory"]}" }'`
- `python -m unittest discover -s .github/tests -p "test_*.py"`

Closes #79
Refs JuliaQUBO/QUBO.jl#30
