### PR TITLE
Skip docs deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,11 @@ jobs:
         uses: julia-actions/julia-buildpkg@latest
         with: 
             project: "docs/"
+      - name: Build docs
+        if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+        run: julia --project=docs/ docs/make.jl --skip-deploy
       - name: Build and deploy
+        if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
The completed Dependabot CI failures share the same root cause: Documenter builds the docs, then fails when it tries to push PR previews to gh-pages with the restricted Dependabot token. This keeps docs builds for Dependabot PRs but passes --skip-deploy so the preview push is skipped. Normal pushes and non-Dependabot PRs still use the deploy path. Verification: julia --project=docs/ docs/make.jl --skip-deploy.