### PR TITLE
[codex] Pin docs setup-julia action to v3

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Julia
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - name: Develop QUBOTools.jl


### PR DESCRIPTION
Pins the Documentation workflow's Julia setup action to the stable v3 major tag.

Why:
- The post-merge Documentation run for PR #91 still emitted the GitHub Actions Node 20 deprecation warning because docs used julia-actions/setup-julia@latest.
- CI and Benchmark already use julia-actions/setup-julia@v3 successfully.

Validation:
- git diff --check
- scanned workflows for remaining actions/checkout@v4 and julia-actions/setup-julia@latest references