### PR TITLE
Add structured SampleSet export/import

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -118,6 +118,7 @@ QUBOTools.hassample
 QUBOTools.AbstractSolution
 QUBOTools.SampleSet
 QUBOTools.solution
+QUBOTools.sampleset_table
 ```
 
 ```@docs
@@ -176,6 +177,8 @@ QUBOTools.write_model
 ```@docs
 QUBOTools.read_solution
 QUBOTools.write_solution
+QUBOTools.read_samples
+QUBOTools.write_samples
 ```
 
 ### Format & I/O Errors

--- a/docs/src/manual/6-solutions.md
+++ b/docs/src/manual/6-solutions.md
@@ -14,7 +14,7 @@ Optimization results and metadata are stored in a specialized data structre, the
 
 ## Tabular distribution caches
 
-Solver-independent sample distributions can be exported as CSV files with [`QUBOTools.write_samples`](@ref) and loaded again with [`QUBOTools.read_samples`](@ref). The CSV schema is stable and includes the sample rank, state, reads, value, and probability by default. Solution metadata, frame information, and package versions are stored as embedded JSON metadata, or in a JSON sidecar when `metadata_path` is provided.
+Solver-independent sample distributions can be exported as CSV files with [`QUBOTools.write_samples`](@ref) and loaded again with [`QUBOTools.read_samples`](@ref). The CSV schema is stable and includes the sample rank, state, reads, value, and probability by default. Solution metadata, frame information, bit order, and package versions are stored as embedded JSON metadata, or in a JSON sidecar when `metadata_path` is provided.
 
 ```julia
 solution = QUBOTools.solution(model)
@@ -42,6 +42,10 @@ cached_solution = QUBOTools.read_samples(
     metadata_path = "distribution.metadata.json",
 )
 ```
+
+For files written with `metadata_path`, pass the same `metadata_path` to [`QUBOTools.read_samples`](@ref) so the recorded frame and bit order are restored. If embedded or sidecar metadata records a bit order, that recorded value is used for import; the `bit_order` keyword is only used for metadata-less CSV input.
+
+[`QUBOTools.read_samples`](@ref) returns a [`QUBOTools.SampleSet`](@ref) with `Float64` values and `Int` reads. Model scale, offset, and variable names are kept in the JSON metadata for external inspection, but `read_samples` does not reconstruct a model from that metadata block.
 
 ## Metadata
 

--- a/docs/src/manual/6-solutions.md
+++ b/docs/src/manual/6-solutions.md
@@ -12,6 +12,37 @@ Samples should be sorted by increasing values of ``\lambda``, then by decreasing
 
 Optimization results and metadata are stored in a specialized data structre, the [`QUBOTools.SampleSet`](@ref).
 
+## Tabular distribution caches
+
+Solver-independent sample distributions can be exported as CSV files with [`QUBOTools.write_samples`](@ref) and loaded again with [`QUBOTools.read_samples`](@ref). The CSV schema is stable and includes the sample rank, state, reads, value, and probability by default. Solution metadata, frame information, and package versions are stored as embedded JSON metadata, or in a JSON sidecar when `metadata_path` is provided.
+
+```julia
+solution = QUBOTools.solution(model)
+
+QUBOTools.write_samples("distribution.csv", solution)
+
+cached_solution = QUBOTools.read_samples("distribution.csv")
+rows = QUBOTools.sampleset_table(cached_solution)
+
+states = getproperty.(rows, :state)
+probabilities = getproperty.(rows, :probability)
+```
+
+When model context is available, passing the model records model scale, offset, and variable names in the metadata sidecar or embedded metadata:
+
+```julia
+QUBOTools.write_samples(
+    "distribution.csv",
+    model;
+    metadata_path = "distribution.metadata.json",
+)
+
+cached_solution = QUBOTools.read_samples(
+    "distribution.csv";
+    metadata_path = "distribution.metadata.json",
+)
+```
+
 ## Metadata
 
 The solution metadata should be stored in a JSON-compatible associative map with string keys, such as `Dict{String,Any}`.

--- a/src/QUBOTools.jl
+++ b/src/QUBOTools.jl
@@ -57,6 +57,7 @@ export ↓, ↑, 𝔹, 𝕊
 
 # Exports: Solution Interface
 export Sample, SampleSet
+export read_samples, sampleset_table, write_samples
 
 # Interface definitions
 include("interface/form.jl")
@@ -90,6 +91,7 @@ include("library/solution/abstract.jl")
 include("library/solution/state.jl")
 include("library/solution/sample.jl")
 include("library/solution/sampleset.jl")
+include("library/solution/table.jl")
 
 include("library/model/abstract.jl")
 include("library/model/variable_map.jl")

--- a/src/library/solution/table.jl
+++ b/src/library/solution/table.jl
@@ -1,0 +1,439 @@
+const _SAMPLE_TABLE_FORMAT = "QUBOTools.samples"
+const _SAMPLE_TABLE_VERSION = 1
+const _SAMPLE_TABLE_METADATA_PREFIX = "# QUBOTools.samples.metadata="
+
+@doc raw"""
+    sampleset_table(sampleset::AbstractSolution; bit_order = :native, include_probability = true)
+
+Return a row table for `sampleset` as a `Vector{NamedTuple}` with stable columns.
+The default columns are `rank`, `state`, `reads`, `value`, and `probability`;
+`probability` is omitted when `include_probability = false`.
+
+The returned vector is compatible with the Tables.jl row-table convention without
+making Tables.jl a package dependency.
+"""
+function sampleset_table(
+    sol::AbstractSolution;
+    bit_order::Union{Symbol,AbstractString} = :native,
+    include_probability::Bool = true,
+)
+    bit_order = _samples_bit_order(bit_order)
+
+    total_reads = reads(sol)
+
+    if include_probability
+        return [
+            (
+                rank = i,
+                state = _samples_state_string(sample; bit_order),
+                reads = reads(sample),
+                value = value(sample),
+                probability = _samples_probability(reads(sample), total_reads),
+            ) for (i, sample) in enumerate(sol)
+        ]
+    else
+        return [
+            (
+                rank = i,
+                state = _samples_state_string(sample; bit_order),
+                reads = reads(sample),
+                value = value(sample),
+            ) for (i, sample) in enumerate(sol)
+        ]
+    end
+end
+
+@doc raw"""
+    write_samples(path::AbstractString, sampleset::AbstractSolution; format = :csv,
+        metadata_path = nothing, bit_order = :native, include_probability = true)
+
+Write a `SampleSet`-like solution as a stable tabular distribution file.
+
+Only `format = :csv` is currently supported. By default, JSON metadata is embedded
+in a leading CSV comment so `read_samples` can recover the solution frame and
+metadata. If `metadata_path` is provided, the JSON metadata is written to that
+sidecar path instead.
+"""
+function write_samples(
+    path::AbstractString,
+    sol::AbstractSolution;
+    format::Union{Symbol,AbstractString} = :csv,
+    metadata_path::Union{AbstractString,Nothing} = nothing,
+    bit_order::Union{Symbol,AbstractString} = :native,
+    include_probability::Bool = true,
+    model::Union{AbstractModel,Nothing} = nothing,
+)
+    format = Symbol(format)
+
+    format === :csv || format_error("Unsupported samples format '$(format)'")
+
+    bit_order = _samples_bit_order(bit_order)
+    columns = _samples_columns(; include_probability)
+    file_metadata = _samples_file_metadata(sol; columns, bit_order, model)
+
+    if !isnothing(metadata_path)
+        _write_samples_metadata(metadata_path, file_metadata)
+    end
+
+    return open(path, "w") do io
+        return write_samples(
+            io,
+            sol;
+            format,
+            metadata = isnothing(metadata_path) ? file_metadata : nothing,
+            bit_order,
+            include_probability,
+        )
+    end
+end
+
+function write_samples(
+    path::AbstractString,
+    model::AbstractModel;
+    kws...,
+)
+    return write_samples(path, solution(model); model, kws...)
+end
+
+function write_samples(
+    io::IO,
+    sol::AbstractSolution;
+    format::Union{Symbol,AbstractString} = :csv,
+    bit_order::Union{Symbol,AbstractString} = :native,
+    include_probability::Bool = true,
+    metadata::Union{Dict{String,Any},Nothing} = _samples_file_metadata(
+        sol;
+        columns = _samples_columns(; include_probability),
+        bit_order = _samples_bit_order(bit_order),
+    ),
+)
+    format = Symbol(format)
+
+    format === :csv || format_error("Unsupported samples format '$(format)'")
+
+    bit_order = _samples_bit_order(bit_order)
+
+    if !isnothing(metadata)
+        println(io, _SAMPLE_TABLE_METADATA_PREFIX, JSON.json(metadata))
+    end
+
+    table = sampleset_table(sol; bit_order, include_probability)
+    columns = _samples_columns(; include_probability)
+
+    _write_samples_csv_record(io, String.(columns))
+
+    for row in table
+        _write_samples_csv_record(io, getproperty.(Ref(row), columns))
+    end
+
+    return nothing
+end
+
+@doc raw"""
+    read_samples(path::AbstractString; metadata_path = nothing, bit_order = :native)
+
+Read a CSV distribution written by [`write_samples`](@ref) and return a
+`SampleSet`. Duplicate states with matching values are merged by the `SampleSet`
+constructor. The `probability` column, when present, is treated as derived data;
+`reads` remains authoritative.
+"""
+function read_samples(
+    path::AbstractString;
+    metadata_path::Union{AbstractString,Nothing} = nothing,
+    bit_order::Union{Symbol,AbstractString} = :native,
+)
+    sidecar_metadata = if isnothing(metadata_path)
+        nothing
+    else
+        _read_samples_metadata(metadata_path)
+    end
+
+    return open(path, "r") do io
+        return read_samples(io; metadata = sidecar_metadata, bit_order)
+    end
+end
+
+function read_samples(
+    io::IO;
+    metadata::Union{Dict{String,Any},Nothing} = nothing,
+    bit_order::Union{Symbol,AbstractString} = :native,
+)
+    bit_order = _samples_bit_order(bit_order)
+    rows, embedded_metadata = _read_samples_csv(io)
+    file_metadata = isnothing(metadata) ? embedded_metadata : metadata
+    bit_order = _samples_read_bit_order(file_metadata, bit_order)
+
+    sample_metadata = _samples_solution_metadata(file_metadata)
+    sample_sense = _samples_sense(file_metadata)
+    sample_domain = _samples_domain(file_metadata)
+
+    samples = Sample{Float64,Int}[]
+
+    for row in rows
+        ψ = _parse_samples_state(row[:state], sample_domain)
+
+        if bit_order === :reverse
+            reverse!(ψ)
+        end
+
+        push!(
+            samples,
+            Sample{Float64,Int}(
+                ψ,
+                parse(Float64, row[:value]),
+                parse(Int, row[:reads]),
+            ),
+        )
+    end
+
+    return SampleSet{Float64,Int}(
+        samples;
+        metadata = sample_metadata,
+        sense = sample_sense,
+        domain = sample_domain,
+    )
+end
+
+function _samples_columns(; include_probability::Bool)
+    if include_probability
+        return (:rank, :state, :reads, :value, :probability)
+    else
+        return (:rank, :state, :reads, :value)
+    end
+end
+
+function _samples_bit_order(bit_order::Union{Symbol,AbstractString})
+    bit_order = Symbol(bit_order)
+
+    if bit_order === :native || bit_order === :reverse
+        return bit_order
+    else
+        format_error("Unsupported sample bit order '$(bit_order)'")
+    end
+end
+
+function _samples_read_bit_order(file_metadata::Nothing, bit_order::Symbol)
+    return bit_order
+end
+
+function _samples_read_bit_order(file_metadata::Dict{String,Any}, bit_order::Symbol)
+    return _samples_bit_order(get(file_metadata, "bit_order", bit_order))
+end
+
+function _samples_probability(sample_reads::Integer, total_reads::Integer)
+    if total_reads == 0
+        return 0.0
+    else
+        return sample_reads / total_reads
+    end
+end
+
+function _samples_state_string(sample::AbstractSample; bit_order::Symbol)
+    ψ = collect(state(sample))
+
+    if bit_order === :reverse
+        reverse!(ψ)
+    end
+
+    if all(x -> x == 0 || x == 1, ψ)
+        return join(string.(ψ), "")
+    else
+        return join(string.(ψ), " ")
+    end
+end
+
+function _samples_file_metadata(
+    sol::AbstractSolution;
+    columns,
+    bit_order::Symbol,
+    model::Union{AbstractModel,Nothing} = nothing,
+)
+    file_metadata = Dict{String,Any}(
+        "format" => _SAMPLE_TABLE_FORMAT,
+        "version" => _SAMPLE_TABLE_VERSION,
+        "package_versions" => Dict{String,Any}(
+            "QUBOTools" => string(__version__()),
+            "Julia" => string(VERSION),
+        ),
+        "sense" => String(sense(sol)),
+        "domain" => String(domain(sol)),
+        "bit_order" => String(bit_order),
+        "columns" => String.(columns),
+        "metadata" => deepcopy(metadata(sol)),
+    )
+
+    if !isnothing(model)
+        file_metadata["model"] = Dict{String,Any}(
+            "scale" => scale(model),
+            "offset" => offset(model),
+            "variables" => string.(variables(model)),
+        )
+    end
+
+    return file_metadata
+end
+
+function _samples_solution_metadata(file_metadata::Nothing)
+    return Dict{String,Any}()
+end
+
+function _samples_solution_metadata(file_metadata::Dict{String,Any})
+    data = get(file_metadata, "metadata", Dict{String,Any}())
+
+    return _json_object(data)
+end
+
+function _samples_sense(file_metadata::Nothing)
+    return Min
+end
+
+function _samples_sense(file_metadata::Dict{String,Any})
+    return QUBOTools.sense(get(file_metadata, "sense", "min"))
+end
+
+function _samples_domain(file_metadata::Nothing)
+    return 𝔹
+end
+
+function _samples_domain(file_metadata::Dict{String,Any})
+    return QUBOTools.domain(get(file_metadata, "domain", "bool"))
+end
+
+function _write_samples_metadata(path::AbstractString, metadata::Dict{String,Any})
+    return open(path, "w") do io
+        JSON.print(io, metadata, 2)
+        println(io)
+
+        return nothing
+    end
+end
+
+function _read_samples_metadata(path::AbstractString)
+    return _json_object(JSON.parsefile(path))
+end
+
+function _write_samples_csv_record(io::IO, values)
+    println(io, join(_samples_csv_cell.(values), ","))
+
+    return nothing
+end
+
+function _samples_csv_cell(value)
+    str = string(value)
+
+    if occursin("\"", str) || occursin(",", str) || occursin("\n", str) ||
+       occursin("\r", str) || startswith(str, "#")
+        return "\"" * replace(str, "\"" => "\"\"") * "\""
+    else
+        return str
+    end
+end
+
+function _read_samples_csv(io::IO)
+    metadata = nothing
+    header = nothing
+    rows = Vector{Dict{Symbol,String}}()
+
+    for line in eachline(io)
+        isempty(strip(line)) && continue
+
+        if startswith(line, "#")
+            if startswith(line, _SAMPLE_TABLE_METADATA_PREFIX)
+                metadata_json = line[nextind(line, lastindex(_SAMPLE_TABLE_METADATA_PREFIX)):end]
+                metadata = _json_object(JSON.parse(metadata_json))
+            end
+
+            continue
+        end
+
+        fields = _parse_samples_csv_record(line)
+
+        if isnothing(header)
+            header = Symbol.(fields)
+            _validate_samples_csv_header(header)
+
+            continue
+        end
+
+        if length(fields) != length(header)
+            syntax_error(
+                "CSV sample row has $(length(fields)) fields, expected $(length(header))",
+            )
+        end
+
+        push!(rows, Dict{Symbol,String}(header[i] => fields[i] for i in eachindex(header)))
+    end
+
+    isnothing(header) && syntax_error("CSV samples file is missing a header row")
+
+    return rows, metadata
+end
+
+function _validate_samples_csv_header(header::Vector{Symbol})
+    for column in (:state, :reads, :value)
+        column in header || syntax_error("CSV samples file is missing required column '$(column)'")
+    end
+
+    return nothing
+end
+
+function _parse_samples_csv_record(line::AbstractString)
+    fields = String[]
+    buffer = IOBuffer()
+    quoted = false
+    i = firstindex(line)
+
+    while i <= lastindex(line)
+        c = line[i]
+
+        if quoted
+            if c == '"'
+                j = nextind(line, i)
+
+                if j <= lastindex(line) && line[j] == '"'
+                    print(buffer, '"')
+                    i = nextind(line, j)
+                else
+                    quoted = false
+                    i = j
+                end
+            else
+                print(buffer, c)
+                i = nextind(line, i)
+            end
+        else
+            if c == ','
+                push!(fields, String(take!(buffer)))
+                i = nextind(line, i)
+            elseif c == '"'
+                quoted = true
+                i = nextind(line, i)
+            else
+                print(buffer, c)
+                i = nextind(line, i)
+            end
+        end
+    end
+
+    quoted && syntax_error("CSV sample row has an unterminated quoted field")
+
+    push!(fields, String(take!(buffer)))
+
+    return fields
+end
+
+function _parse_samples_state(cell::AbstractString, sample_domain::Domain)
+    text = strip(cell)
+
+    isempty(text) && return Int[]
+
+    tokens = if occursin(r"[\s,;]", text)
+        split(replace(replace(text, "," => " "), ";" => " "))
+    elseif sample_domain === 𝔹 && all(c -> c == '0' || c == '1', text)
+        string.(collect(text))
+    else
+        [text]
+    end
+
+    return parse.(Int, tokens)
+end

--- a/src/library/solution/table.jl
+++ b/src/library/solution/table.jl
@@ -18,6 +18,7 @@ function sampleset_table(
     include_probability::Bool = true,
 )
     bit_order = _samples_bit_order(bit_order)
+    sample_domain = domain(sol)
 
     total_reads = reads(sol)
 
@@ -25,7 +26,7 @@ function sampleset_table(
         return [
             (
                 rank = i,
-                state = _samples_state_string(sample; bit_order),
+                state = _samples_state_string(sample, sample_domain; bit_order),
                 reads = reads(sample),
                 value = value(sample),
                 probability = _samples_probability(reads(sample), total_reads),
@@ -35,7 +36,7 @@ function sampleset_table(
         return [
             (
                 rank = i,
-                state = _samples_state_string(sample; bit_order),
+                state = _samples_state_string(sample, sample_domain; bit_order),
                 reads = reads(sample),
                 value = value(sample),
             ) for (i, sample) in enumerate(sol)
@@ -52,7 +53,9 @@ Write a `SampleSet`-like solution as a stable tabular distribution file.
 Only `format = :csv` is currently supported. By default, JSON metadata is embedded
 in a leading CSV comment so `read_samples` can recover the solution frame and
 metadata. If `metadata_path` is provided, the JSON metadata is written to that
-sidecar path instead.
+sidecar path instead and must be passed to `read_samples` to recover the recorded
+frame and metadata. When `model` context is provided, model scale, offset, and
+variable names are recorded in the JSON metadata.
 """
 function write_samples(
     path::AbstractString,
@@ -135,7 +138,14 @@ end
 Read a CSV distribution written by [`write_samples`](@ref) and return a
 `SampleSet`. Duplicate states with matching values are merged by the `SampleSet`
 constructor. The `probability` column, when present, is treated as derived data;
-`reads` remains authoritative.
+`reads` remains authoritative. Imported values use `Float64` and reads use `Int`.
+
+When embedded or sidecar metadata records `bit_order`, that recorded order is
+used to recover the native state order; the `bit_order` keyword is used only for
+metadata-less input. Sidecar metadata written by `write_samples` must be supplied
+with `metadata_path` to recover the recorded frame and solution metadata.
+`read_samples` returns a `SampleSet` and does not reconstruct model context from
+the optional metadata `model` block.
 """
 function read_samples(
     path::AbstractString;
@@ -228,14 +238,18 @@ function _samples_probability(sample_reads::Integer, total_reads::Integer)
     end
 end
 
-function _samples_state_string(sample::AbstractSample; bit_order::Symbol)
+function _samples_state_string(
+    sample::AbstractSample,
+    sample_domain::Domain;
+    bit_order::Symbol,
+)
     ψ = collect(state(sample))
 
     if bit_order === :reverse
         reverse!(ψ)
     end
 
-    if all(x -> x == 0 || x == 1, ψ)
+    if sample_domain === 𝔹
         return join(string.(ψ), "")
     else
         return join(string.(ψ), " ")

--- a/test/unit/library/solution.jl
+++ b/test/unit/library/solution.jl
@@ -272,11 +272,130 @@ function test_solution_sampleset()
     end
 end
 
+function test_solution_sampleset_io()
+    @testset "⋅ SampleSet Tables & I/O" begin
+        metadata = Dict{String,Any}(
+            "origin" => "test-solver",
+            "time" => Dict{String,Any}("total" => 1.25),
+            "model" => Dict{String,Any}(
+                "scale" => 2.0,
+                "offset" => -1.0,
+                "variables" => ["x1", "x2", "x3"],
+            ),
+        )
+
+        sol = SampleSet{Float64,Int}(
+            Sample{Float64,Int}[
+                Sample([0, 1, 1], 1.5, 2),
+                Sample([1, 0, 0], -2.0, 3),
+                Sample([0, 1, 1], 1.5, 4),
+            ];
+            metadata,
+            sense = :min,
+            domain = :bool,
+        )
+
+        rows = QUBOTools.sampleset_table(sol)
+
+        @test propertynames(first(rows)) == (:rank, :state, :reads, :value, :probability)
+        @test rows[1] == (rank = 1, state = "100", reads = 3, value = -2.0, probability = 1 / 3)
+        @test rows[2] == (rank = 2, state = "011", reads = 6, value = 1.5, probability = 2 / 3)
+
+        rows_without_probability = QUBOTools.sampleset_table(sol; include_probability = false)
+
+        @test propertynames(first(rows_without_probability)) == (:rank, :state, :reads, :value)
+
+        zero_read_sol = SampleSet{Float64,Int}(
+            Sample{Float64,Int}[
+                Sample([0, 0], 0.0, 0),
+                Sample([1, 1], 1.0, 0),
+            ];
+            sense = :min,
+            domain = :bool,
+        )
+
+        @test all(row -> row.probability == 0.0, QUBOTools.sampleset_table(zero_read_sol))
+
+        mktempdir() do dir
+            samples_path = joinpath(dir, "samples.csv")
+
+            QUBOTools.write_samples(samples_path, sol)
+
+            samples_text = read(samples_path, String)
+
+            @test occursin("# QUBOTools.samples.metadata=", samples_text)
+            @test occursin("rank,state,reads,value,probability", samples_text)
+
+            dst = QUBOTools.read_samples(samples_path)
+
+            @test _compare_solutions(sol, dst)
+
+            samples_without_probability_path = joinpath(dir, "samples-without-probability.csv")
+
+            QUBOTools.write_samples(
+                samples_without_probability_path,
+                sol;
+                include_probability = false,
+            )
+
+            @test occursin("rank,state,reads,value\n", read(samples_without_probability_path, String))
+
+            spin_sol = SampleSet{Float64,Int}(
+                Sample{Float64,Int}[
+                    Sample([↓, ↑, ↓], -3.0, 5),
+                    Sample([↑, ↓, ↑], -1.0, 7),
+                ];
+                metadata = Dict{String,Any}("origin" => "spin-solver"),
+                sense = :max,
+                domain = :spin,
+            )
+
+            spin_samples_path = joinpath(dir, "spin-samples.csv")
+            spin_metadata_path = joinpath(dir, "spin-samples.json")
+
+            QUBOTools.write_samples(
+                spin_samples_path,
+                spin_sol;
+                metadata_path = spin_metadata_path,
+                bit_order = :reverse,
+            )
+
+            @test !startswith(read(spin_samples_path, String), "#")
+            @test occursin("\"domain\": \"spin\"", read(spin_metadata_path, String))
+
+            spin_dst = QUBOTools.read_samples(
+                spin_samples_path;
+                metadata_path = spin_metadata_path,
+            )
+
+            @test _compare_solutions(spin_sol, spin_dst)
+
+            duplicate_samples_path = joinpath(dir, "duplicate-samples.csv")
+
+            open(duplicate_samples_path, "w") do io
+                println(io, "rank,state,reads,value,probability")
+                println(io, "1,01,2,1.0,0.4")
+                println(io, "2,01,3,1.0,0.6")
+            end
+
+            duplicate_dst = QUBOTools.read_samples(duplicate_samples_path)
+
+            @test length(duplicate_dst) == 1
+            @test QUBOTools.state(duplicate_dst, 1) == [0, 1]
+            @test QUBOTools.value(duplicate_dst, 1) == 1.0
+            @test QUBOTools.reads(duplicate_dst, 1) == 5
+        end
+    end
+
+    return nothing
+end
+
 function test_solution()
     @testset "→ Solution" verbose = true begin
         test_solution_states()
         test_solution_samples()
         test_solution_sampleset()
+        test_solution_sampleset_io()
     end
 
     return nothing

--- a/test/unit/library/solution.jl
+++ b/test/unit/library/solution.jl
@@ -342,6 +342,7 @@ function test_solution_sampleset_io()
 
             spin_sol = SampleSet{Float64,Int}(
                 Sample{Float64,Int}[
+                    Sample([↑, ↑, ↑], -4.0, 2),
                     Sample([↓, ↑, ↓], -3.0, 5),
                     Sample([↑, ↓, ↑], -1.0, 7),
                 ];
@@ -360,8 +361,12 @@ function test_solution_sampleset_io()
                 bit_order = :reverse,
             )
 
-            @test !startswith(read(spin_samples_path, String), "#")
-            @test occursin("\"domain\": \"spin\"", read(spin_metadata_path, String))
+            spin_samples_text = read(spin_samples_path, String)
+            spin_metadata_text = read(spin_metadata_path, String)
+
+            @test !startswith(spin_samples_text, "#")
+            @test occursin("1 1 1", spin_samples_text)
+            @test occursin("\"domain\": \"spin\"", spin_metadata_text)
 
             spin_dst = QUBOTools.read_samples(
                 spin_samples_path;
@@ -369,6 +374,43 @@ function test_solution_sampleset_io()
             )
 
             @test _compare_solutions(spin_sol, spin_dst)
+
+            spin_dst_with_explicit_native = QUBOTools.read_samples(
+                spin_samples_path;
+                metadata_path = spin_metadata_path,
+                bit_order = :native,
+            )
+
+            @test _compare_solutions(spin_sol, spin_dst_with_explicit_native)
+
+            model = QUBOTools.Model(
+                Dict(:x1 => 1.0, :x2 => 0.0, :x3 => -1.0),
+                Dict{Tuple{Symbol,Symbol},Float64}();
+                scale = 2.0,
+                offset = -1.0,
+            )
+
+            QUBOTools.attach!(model, sol)
+
+            model_samples_path = joinpath(dir, "model-samples.csv")
+            model_metadata_path = joinpath(dir, "model-samples.json")
+
+            QUBOTools.write_samples(
+                model_samples_path,
+                model;
+                metadata_path = model_metadata_path,
+            )
+
+            model_metadata_text = read(model_metadata_path, String)
+
+            @test occursin("\"scale\": 2.0", model_metadata_text)
+            @test occursin("\"offset\": -1.0", model_metadata_text)
+            @test occursin("\"variables\":", model_metadata_text)
+            @test occursin("\"x1\"", model_metadata_text)
+            @test _compare_solutions(
+                sol,
+                QUBOTools.read_samples(model_samples_path; metadata_path = model_metadata_path),
+            )
 
             duplicate_samples_path = joinpath(dir, "duplicate-samples.csv")
 


### PR DESCRIPTION
## Summary

- Add `sampleset_table`, `write_samples`, and `read_samples` for solver-independent `SampleSet` distribution caches.
- Write stable CSV rows with `rank,state,reads,value,probability`, with optional probability omission and native/reverse state ordering.
- Preserve solution metadata, sense/domain, package versions, and optional model scale/offset/variables through embedded JSON metadata or a JSON sidecar.
- Document the save/reload/replot workflow and add unit coverage for round-trips, zero reads, duplicate imported states, sidecar metadata, and reverse ordering.

Closes #93

## Tests

- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using QUBOTools; println("loaded")'`
- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using QUBOTools; mktempdir() do dir; sol = SampleSet{Float64,Int}(Sample{Float64,Int}[Sample([0, 1], 1.0, 2), Sample([0, 1], 1.0, 3)]; metadata = Dict{String,Any}("origin" => "smoke"), sense = :min, domain = :bool); path = joinpath(dir, "samples.csv"); write_samples(path, sol); dst = read_samples(path); @assert length(dst) == 1; @assert QUBOTools.reads(dst, 1) == 5; @assert QUBOTools.metadata(dst)["origin"] == "smoke"; @assert sampleset_table(dst)[1].probability == 1.0; end; println("samples smoke ok")'`
- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using QUBOTools; mktempdir() do dir; path = joinpath(dir, "dups.csv"); open(path, "w") do io; println(io, "rank,state,reads,value,probability"); println(io, "1,01,2,1.0,0.4"); println(io, "2,01,3,1.0,0.6"); end; dst = read_samples(path); @assert length(dst) == 1; @assert QUBOTools.state(dst, 1) == [0, 1]; @assert QUBOTools.reads(dst, 1) == 5; end; println("no metadata import ok")'`
- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using QUBOTools; mktempdir() do dir; sol = SampleSet{Float64,Int}(Sample{Float64,Int}[Sample([1, -1, 1], 2.0, 4)]; sense = :max, domain = :spin); path = joinpath(dir, "spin.csv"); meta = joinpath(dir, "spin.json"); write_samples(path, sol; metadata_path = meta, bit_order = :reverse); dst = read_samples(path; metadata_path = meta); @assert QUBOTools.state(dst, 1) == [1, -1, 1]; @assert QUBOTools.sense(dst) === QUBOTools.Max; @assert QUBOTools.domain(dst) === QUBOTools.SpinDomain; end; println("metadata bit order ok")'`
- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using Pkg; Pkg.test()'` passes with 671 tests.

Notes: `Pkg.test()` re-resolved the temporary test environment and emitted the repo's existing Documenter warning about undocumented docstrings; the suite passed.
