### PR TITLE
Add objective bookkeeping helpers

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -128,6 +128,15 @@ QUBOTools.energy
 QUBOTools.reads
 ```
 
+```@docs
+QUBOTools.ObjectiveBreakdown
+QUBOTools.ObjectiveMismatch
+QUBOTools.objective_breakdown
+QUBOTools.annotate_objectives!
+QUBOTools.objective_value_mismatches
+QUBOTools.verify_objective_values
+```
+
 ### Solution Errors
 
 ```@docs

--- a/src/QUBOTools.jl
+++ b/src/QUBOTools.jl
@@ -58,6 +58,9 @@ export ↓, ↑, 𝔹, 𝕊
 # Exports: Solution Interface
 export Sample, SampleSet
 export read_samples, sampleset_table, write_samples
+export ObjectiveBreakdown, ObjectiveMismatch
+export annotate_objectives!, objective_breakdown
+export objective_value_mismatches, verify_objective_values
 
 # Interface definitions
 include("interface/form.jl")
@@ -96,6 +99,7 @@ include("library/solution/table.jl")
 include("library/model/abstract.jl")
 include("library/model/variable_map.jl")
 include("library/model/model.jl")
+include("library/model/objective.jl")
 
 include("library/synthesis/abstract.jl")
 include("library/synthesis/sherrington_kirkpatrick.jl")

--- a/src/interface/solution.jl
+++ b/src/interface/solution.jl
@@ -88,6 +88,43 @@ An alias for [`value`](@ref).
 const energy = value
 
 @doc raw"""
+    objective_breakdown(model_or_form, state; variables = nothing)
+    objective_breakdown(model, sample)
+
+Return a structured objective-value breakdown for `state`.
+
+The breakdown separates the raw quadratic value, the scaled value, and the
+offset-adjusted value used by [`value`](@ref). When `variables` is provided for
+a model and vector state, the vector is interpreted in that variable order and
+projected to the model's variable order before evaluation.
+"""
+function objective_breakdown end
+
+@doc raw"""
+    annotate_objectives!(sampleset, model; label = :objective, variables = nothing)
+
+Compute objective breakdown rows for each sample and store them under
+`metadata(sampleset)["objectives"][label]`.
+"""
+function annotate_objectives! end
+
+@doc raw"""
+    objective_value_mismatches(model, sampleset; atol = 0, rtol = sqrt(eps(Float64)))
+
+Return detailed records for samples whose stored values do not match model
+evaluation within tolerance.
+"""
+function objective_value_mismatches end
+
+@doc raw"""
+    verify_objective_values(model, sampleset; kws...)
+
+Return `true` when every stored sample value matches model evaluation within the
+given tolerance.
+"""
+function verify_objective_values end
+
+@doc raw"""
     read_solution(::AbstractString)
     read_solution(::AbstractString, ::AbstractFormat)
     read_solution(::IO, ::AbstractFormat)

--- a/src/interface/solution.jl
+++ b/src/interface/solution.jl
@@ -90,13 +90,19 @@ const energy = value
 @doc raw"""
     objective_breakdown(model_or_form, state; variables = nothing)
     objective_breakdown(model, sample)
+    objective_breakdown(model, i::Integer)
 
 Return a structured objective-value breakdown for `state`.
 
 The breakdown separates the raw quadratic value, the scaled value, and the
 offset-adjusted value used by [`value`](@ref). When `variables` is provided for
 a model and vector state, the vector is interpreted in that variable order and
-projected to the model's variable order before evaluation.
+projected to the model's variable order before evaluation. The `sample` and
+integer overloads evaluate state data without a surrounding solution frame, so
+the state is assumed to already be in the model domain; use
+[`annotate_objectives!`](@ref) or [`verify_objective_values`](@ref) when
+evaluating samples from a `SampleSet` whose frame may differ from the model. The
+integer overload interprets `i` as the index of a sample in `solution(model)`.
 """
 function objective_breakdown end
 
@@ -104,7 +110,9 @@ function objective_breakdown end
     annotate_objectives!(sampleset, model; label = :objective, variables = nothing)
 
 Compute objective breakdown rows for each sample and store them under
-`metadata(sampleset)["objectives"][label]`.
+`metadata(sampleset)["objectives"][label]`. Stored rows record the evaluated
+state, after any solution-domain cast or variable projection needed to evaluate
+against `model`.
 """
 function annotate_objectives! end
 

--- a/src/library/model/objective.jl
+++ b/src/library/model/objective.jl
@@ -1,0 +1,320 @@
+@doc raw"""
+    ObjectiveBreakdown
+
+Structured objective evaluation for a state.
+
+Fields:
+
+- `state`: state vector in the evaluated model or form domain;
+- `raw_value`: linear plus quadratic value before scale and offset;
+- `scaled_value`: `scale * raw_value`;
+- `offset_adjusted_value`: `scale * (raw_value + offset)`, matching [`value`](@ref);
+- `scale`, `offset`, `sense`, and `domain`: frame data used for evaluation.
+"""
+struct ObjectiveBreakdown{T<:Real,U<:Integer}
+    state::Vector{U}
+    raw_value::T
+    scaled_value::T
+    offset_adjusted_value::T
+    scale::T
+    offset::T
+    sense::Sense
+    domain::Domain
+end
+
+function ObjectiveBreakdown(
+    state::AbstractVector{U},
+    raw_value::R,
+    scaled_value::S,
+    offset_adjusted_value::A,
+    scale::C,
+    offset::O,
+    sense::Sense,
+    domain::Domain,
+) where {U<:Integer,R<:Real,S<:Real,A<:Real,C<:Real,O<:Real}
+    T = promote_type(R, S, A, C, O)
+
+    return ObjectiveBreakdown{T,U}(
+        collect(state),
+        raw_value,
+        scaled_value,
+        offset_adjusted_value,
+        scale,
+        offset,
+        sense,
+        domain,
+    )
+end
+
+value(breakdown::ObjectiveBreakdown) = breakdown.offset_adjusted_value
+
+@doc raw"""
+    ObjectiveMismatch
+
+Detailed record for one stored sample value that does not match model
+evaluation.
+"""
+struct ObjectiveMismatch{T<:Real,U<:Integer}
+    index::Int
+    state::Vector{U}
+    stored_value::T
+    evaluated_value::T
+    difference::T
+end
+
+function ObjectiveMismatch(
+    index::Integer,
+    state::AbstractVector{U},
+    stored_value::S,
+    evaluated_value::E,
+) where {U<:Integer,S<:Real,E<:Real}
+    T = promote_type(S, E)
+
+    return ObjectiveMismatch{T,U}(
+        Int(index),
+        collect(state),
+        stored_value,
+        evaluated_value,
+        stored_value - evaluated_value,
+    )
+end
+
+function objective_breakdown(
+    model::AbstractModel,
+    sample::AbstractSample;
+    kws...,
+)
+    return objective_breakdown(model, state(sample); kws...)
+end
+
+function objective_breakdown(
+    model::AbstractModel,
+    i::Integer;
+    kws...,
+)
+    return objective_breakdown(model, state(model, i); kws...)
+end
+
+function objective_breakdown(
+    model::AbstractModel,
+    state;
+    variables = nothing,
+)
+    psi = _objective_state(model, state; variables)
+
+    return objective_breakdown(form(model), psi)
+end
+
+function objective_breakdown(
+    form::AbstractForm,
+    state::State;
+    variables = nothing,
+)
+    if !isnothing(variables)
+        solution_error("State projection by variables requires model variable metadata")
+    end
+
+    _objective_validate_state_length(form, state)
+    _objective_validate_state_domain(state, domain(form))
+
+    raw_value = _objective_raw_value(state, form)
+    alpha = scale(form)
+    beta = offset(form)
+    scaled_value = alpha * raw_value
+    offset_adjusted_value = alpha * (raw_value + beta)
+
+    return ObjectiveBreakdown(
+        state,
+        raw_value,
+        scaled_value,
+        offset_adjusted_value,
+        alpha,
+        beta,
+        sense(form),
+        domain(form),
+    )
+end
+
+function annotate_objectives!(
+    sol::AbstractSolution,
+    model::AbstractModel;
+    label::Union{Symbol,AbstractString} = :objective,
+    variables = nothing,
+)
+    label = String(label)
+    isempty(label) && solution_error("Objective annotation label cannot be empty")
+
+    rows = [
+        _objective_annotation_row(
+            i,
+            _objective_breakdown(model, sol, sample; variables),
+        ) for (i, sample) in enumerate(sol)
+    ]
+
+    objectives = get!(metadata(sol), "objectives") do
+        Dict{String,Any}()
+    end
+
+    objectives isa AbstractDict ||
+        solution_error("SampleSet metadata entry 'objectives' must be a dictionary")
+
+    objectives[label] = [_objective_metadata_row(row) for row in rows]
+
+    return rows
+end
+
+function objective_value_mismatches(
+    model::AbstractModel,
+    sol::AbstractSolution;
+    atol::Real = 0,
+    rtol::Real = sqrt(eps(Float64)),
+    variables = nothing,
+)
+    mismatches = ObjectiveMismatch[]
+
+    for (i, sample) in enumerate(sol)
+        breakdown = _objective_breakdown(model, sol, sample; variables)
+        stored_value = _objective_stored_value(model, sol, sample)
+        evaluated_value = value(breakdown)
+
+        if !isapprox(stored_value, evaluated_value; atol, rtol)
+            push!(
+                mismatches,
+                ObjectiveMismatch(i, breakdown.state, stored_value, evaluated_value),
+            )
+        end
+    end
+
+    return mismatches
+end
+
+function verify_objective_values(
+    model::AbstractModel,
+    sol::AbstractSolution;
+    kws...,
+)
+    return isempty(objective_value_mismatches(model, sol; kws...))
+end
+
+function _objective_breakdown(
+    model::AbstractModel,
+    sol::AbstractSolution,
+    sample::AbstractSample;
+    variables = nothing,
+)
+    psi = _objective_state(model, state(sample); variables)
+    psi = cast((domain(sol) => domain(model)), psi)
+
+    return objective_breakdown(model, psi)
+end
+
+function _objective_raw_value(state::State, form::AbstractForm)
+    return value(state, data(linear_form(form))) + value(state, data(quadratic_form(form)))
+end
+
+function _objective_state(
+    model::AbstractModel,
+    state::AbstractVector{<:Integer};
+    variables = nothing,
+)
+    if isnothing(variables)
+        _objective_validate_state_length(model, state)
+
+        return collect(state)
+    end
+
+    length(state) == length(variables) ||
+        solution_error("State length must match the provided variable order")
+
+    positions = Dict{Any,Int}(variable => i for (i, variable) in enumerate(variables))
+
+    return [
+        begin
+            variable_i = variable(model, i)
+
+            haskey(positions, variable_i) ||
+                solution_error("State projection is missing variable '$(variable_i)'")
+
+            state[positions[variable_i]]
+        end for i in indices(model)
+    ]
+end
+
+function _objective_state(
+    model::AbstractModel,
+    state::AbstractDict;
+    variables = nothing,
+)
+    if !isnothing(variables)
+        solution_error("Dictionary states are projected by their keys, not by variables")
+    end
+
+    psi = Int[]
+    sizehint!(psi, dimension(model))
+
+    for i in indices(model)
+        variable_i = variable(model, i)
+
+        haskey(state, variable_i) ||
+            solution_error("State assignment is missing variable '$(variable_i)'")
+
+        value_i = state[variable_i]
+        value_i isa Integer ||
+            solution_error("State assignment for variable '$(variable_i)' must be integer")
+
+        push!(psi, Int(value_i))
+    end
+
+    return psi
+end
+
+function _objective_validate_state_length(src, state::AbstractVector)
+    length(state) == dimension(src) ||
+        solution_error("State length $(length(state)) does not match dimension $(dimension(src))")
+
+    return nothing
+end
+
+function _objective_validate_state_domain(state::AbstractVector, domain::Domain)
+    if domain === BoolDomain
+        all(value -> value == 0 || value == 1, state) ||
+            solution_error("BoolDomain states must contain only 0 and 1")
+    elseif domain === SpinDomain
+        all(value -> value == -1 || value == 1, state) ||
+            solution_error("SpinDomain states must contain only -1 and 1")
+    end
+
+    return nothing
+end
+
+function _objective_stored_value(
+    model::AbstractModel,
+    sol::AbstractSolution,
+    sample::AbstractSample,
+)
+    stored_value = value(sample)
+
+    if sense(sol) !== sense(model)
+        stored_value = -stored_value
+    end
+
+    return stored_value
+end
+
+function _objective_annotation_row(index::Integer, breakdown::ObjectiveBreakdown)
+    return (
+        rank = Int(index),
+        state = breakdown.state,
+        raw_value = breakdown.raw_value,
+        scaled_value = breakdown.scaled_value,
+        offset_adjusted_value = breakdown.offset_adjusted_value,
+        scale = breakdown.scale,
+        offset = breakdown.offset,
+        sense = String(breakdown.sense),
+        domain = String(breakdown.domain),
+    )
+end
+
+function _objective_metadata_row(row::NamedTuple)
+    return Dict{String,Any}(String(key) => getproperty(row, key) for key in keys(row))
+end

--- a/test/unit/library/solution.jl
+++ b/test/unit/library/solution.jl
@@ -510,6 +510,14 @@ function test_solution_objectives()
         @test projected_breakdown.state == state
         @test projected_breakdown.offset_adjusted_value == 1.0
 
+        sample_breakdown = QUBOTools.objective_breakdown(
+            model,
+            Sample{Float64,Int}([1, 1, 0], 1.0, 1),
+        )
+
+        @test sample_breakdown.state == state
+        @test sample_breakdown.offset_adjusted_value == 1.0
+
         sol = SampleSet{Float64,Int}(
             Sample{Float64,Int}[
                 Sample([1, 1, 0], 1.0, 2),
@@ -518,6 +526,13 @@ function test_solution_objectives()
             sense = :min,
             domain = :bool,
         )
+
+        QUBOTools.attach!(model, sol)
+
+        indexed_breakdown = QUBOTools.objective_breakdown(model, 2)
+
+        @test indexed_breakdown.state == state
+        @test indexed_breakdown.offset_adjusted_value == 1.0
 
         rows = QUBOTools.annotate_objectives!(sol, model; label = :qubo)
 
@@ -536,7 +551,16 @@ function test_solution_objectives()
             domain = :spin,
         )
 
+        @test_throws QUBOTools.SolutionError QUBOTools.objective_breakdown(
+            model,
+            Sample{Float64,Int}([↑, ↑, ↓], -1.0, 1),
+        )
         @test QUBOTools.verify_objective_values(model, flipped_sol)
+
+        flipped_rows = QUBOTools.annotate_objectives!(flipped_sol, model; label = :cast)
+
+        @test flipped_rows[1].state == [1, 1, 0]
+        @test QUBOTools.metadata(flipped_sol)["objectives"]["cast"][1]["state"] == [1, 1, 0]
 
         bad_sol = SampleSet{Float64,Int}(
             Sample{Float64,Int}[

--- a/test/unit/library/solution.jl
+++ b/test/unit/library/solution.jl
@@ -432,12 +432,146 @@ function test_solution_sampleset_io()
     return nothing
 end
 
+function test_solution_objectives()
+    @testset "⋅ Objective Bookkeeping" begin
+        L = [1.0, -2.0, 0.5]
+        Q = [
+            0.0 3.0 0.0
+            0.0 0.0 -1.0
+            0.0 0.0 0.0
+        ]
+        state = [1, 1, 0]
+
+        dense_form = QUBOTools.DenseForm{Float64}(
+            3,
+            L,
+            Q,
+            2.0,
+            -1.5;
+            sense = :min,
+            domain = :bool,
+        )
+        sparse_form = QUBOTools.SparseForm{Float64}(
+            3,
+            sparse(L),
+            sparse(Q),
+            2.0,
+            -1.5;
+            sense = :min,
+            domain = :bool,
+        )
+
+        dense_breakdown = QUBOTools.objective_breakdown(dense_form, state)
+        sparse_breakdown = QUBOTools.objective_breakdown(sparse_form, state)
+
+        @test dense_breakdown.raw_value == 2.0
+        @test dense_breakdown.scaled_value == 4.0
+        @test dense_breakdown.offset_adjusted_value == 1.0
+        @test QUBOTools.value(dense_breakdown) == 1.0
+        @test dense_breakdown.sense === QUBOTools.Min
+        @test dense_breakdown.domain === QUBOTools.BoolDomain
+        @test sparse_breakdown.raw_value == dense_breakdown.raw_value
+        @test sparse_breakdown.offset_adjusted_value == dense_breakdown.offset_adjusted_value
+
+        spin_model = QUBOTools.Model(
+            Dict(:a => 1.0, :b => -2.0),
+            Dict((:a, :b) => 0.5);
+            scale = 0.5,
+            offset = 2.0,
+            sense = :max,
+            domain = :spin,
+        )
+        spin_breakdown = QUBOTools.objective_breakdown(
+            spin_model,
+            Dict(:a => ↑, :b => ↓),
+        )
+
+        @test spin_breakdown.raw_value == 2.5
+        @test spin_breakdown.scaled_value == 1.25
+        @test spin_breakdown.offset_adjusted_value == 2.25
+        @test spin_breakdown.sense === QUBOTools.Max
+        @test spin_breakdown.domain === QUBOTools.SpinDomain
+
+        model = QUBOTools.Model(
+            Dict(:x => 1.0, :y => -2.0, :z => 0.5),
+            Dict((:x, :y) => 3.0, (:y, :z) => -1.0);
+            scale = 2.0,
+            offset = -1.5,
+            sense = :min,
+            domain = :bool,
+        )
+
+        projected_breakdown = QUBOTools.objective_breakdown(
+            model,
+            [0, 1, 1, 0];
+            variables = [:aux, :x, :y, :z],
+        )
+
+        @test projected_breakdown.state == state
+        @test projected_breakdown.offset_adjusted_value == 1.0
+
+        sol = SampleSet{Float64,Int}(
+            Sample{Float64,Int}[
+                Sample([1, 1, 0], 1.0, 2),
+                Sample([0, 0, 0], -3.0, 1),
+            ];
+            sense = :min,
+            domain = :bool,
+        )
+
+        rows = QUBOTools.annotate_objectives!(sol, model; label = :qubo)
+
+        @test length(rows) == 2
+        @test rows[1].offset_adjusted_value == -3.0
+        @test rows[2].offset_adjusted_value == 1.0
+        @test haskey(QUBOTools.metadata(sol), "objectives")
+        @test QUBOTools.metadata(sol)["objectives"]["qubo"][2]["raw_value"] == 2.0
+        @test QUBOTools.verify_objective_values(model, sol)
+
+        flipped_sol = SampleSet{Float64,Int}(
+            Sample{Float64,Int}[
+                Sample([↑, ↑, ↓], -1.0, 1),
+            ];
+            sense = :max,
+            domain = :spin,
+        )
+
+        @test QUBOTools.verify_objective_values(model, flipped_sol)
+
+        bad_sol = SampleSet{Float64,Int}(
+            Sample{Float64,Int}[
+                Sample([1, 1, 0], 1.25, 1),
+            ];
+            sense = :min,
+            domain = :bool,
+        )
+        mismatches = QUBOTools.objective_value_mismatches(model, bad_sol; atol = 1e-9)
+
+        @test !QUBOTools.verify_objective_values(model, bad_sol; atol = 1e-9)
+        @test length(mismatches) == 1
+        @test mismatches[1].index == 1
+        @test mismatches[1].stored_value == 1.25
+        @test mismatches[1].evaluated_value == 1.0
+        @test mismatches[1].difference == 0.25
+
+        @test_throws QUBOTools.SolutionError QUBOTools.objective_breakdown(model, [2, 1, 0])
+        @test_throws QUBOTools.SolutionError QUBOTools.objective_breakdown(
+            model,
+            [1, 0];
+            variables = [:x, :y],
+        )
+    end
+
+    return nothing
+end
+
 function test_solution()
     @testset "→ Solution" verbose = true begin
         test_solution_states()
         test_solution_samples()
         test_solution_sampleset()
         test_solution_sampleset_io()
+        test_solution_objectives()
     end
 
     return nothing


### PR DESCRIPTION
Summary:
- add `ObjectiveBreakdown` and `objective_breakdown` for raw, scaled, and offset-adjusted objective evaluation
- add SampleSet objective annotations under `metadata(sampleset)["objectives"][label]`
- add stored-value verification helpers with detailed mismatch records
- support dictionary states and variable-order projection for model-backed state evaluation

Tests:
- `julia +release --project=. -e 'using Test, SparseArrays, QUBOTools; include("test/unit/library/solution.jl"); test_solution_objectives()'`
- `julia +release --project=. -e 'using Test, SparseArrays, QUBOTools; include("test/assets/comparison.jl"); include("test/unit/library/solution.jl"); test_solution()'`
- `julia +release --project=. -e 'push!(LOAD_PATH, joinpath(pwd(), "test")); include("test/runtests.jl")'`

Notes:
- `julia --project=. -e 'using QUBOTools'` under Julia 1.10.11 did not run locally because the current root manifest is resolved for Julia 1.12.0 and was missing `OpenSSL_jll` for the 1.10 environment.

Closes #94
