### PR TITLE
Benchmark docs workflow caching

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,10 +14,11 @@ jobs:
         uses: julia-actions/setup-julia@v3
         with:
           version: '1'
+      - uses: julia-actions/cache@v3
       - name: Develop QUBOTools.jl
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd())'
       - name: Build Package
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
         with: 
             project: "docs/"
       - name: Build docs


### PR DESCRIPTION
Summary:
- Add `julia-actions/cache@v3` to the documentation workflow after Julia setup.
- Pin `julia-actions/julia-buildpkg` from `@latest` to `@v1`.
- Leave the existing pull request and main/tag docs build conditions unchanged.

Benchmark results:
- Cold docs run, attempt 1: https://github.com/JuliaQUBO/QUBOTools.jl/actions/runs/27143035254/job/80113127902
- Warm docs rerun, attempt 2: https://github.com/JuliaQUBO/QUBOTools.jl/actions/runs/27143035254/job/80115787234

| Step | Cold | Warm |
| --- | ---: | ---: |
| Total job | 5m34s | 1m47s |
| Setup Julia | 8s | 9s |
| Cache restore | 1s | 11s |
| Develop QUBOTools.jl | 22s | 7s |
| Build Package | 3s | 4s |
| Build and deploy | 4m44s | 59s |
| Cache save/cleanup | 9s | 9s |

The cold run reported `No cache found` and saved a cache successfully. The warm rerun reported a cache hit and restored the cache successfully.

The warm-cache docs job improved by 3m47s, about 68%, so the cache step meets the issue's material-improvement threshold.

Tests:
- `actionlint .github/workflows/docs.yml` passed.
- `julia --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'` passed.
- `julia --project=docs/ docs/make.jl --skip-deploy` passed with existing Documenter warnings about uncataloged docstrings and large example HTML representations.
- PR checks passed on https://github.com/JuliaQUBO/QUBOTools.jl/pull/98.

Closes #97
