### PR TITLE
Implement variable fixing for forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # QUBOTools.jl Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- Replace the unusable `fix_variables(fix, form)` stub with `fix_variables(form, fix::AbstractDict)`, requiring fixed variable values and returning the reduced form, raw offset delta, and old-to-new index map.
+
+### Features
+
+- Add `lift_state` for reconstructing full states from variable-fixing reductions.
+
 ## v0.12.1 (2026-05-28)
 
 ### Compatibility

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -76,6 +76,11 @@ QUBOTools.qubo
 QUBOTools.ising
 ```
 
+```@docs
+QUBOTools.fix_variables
+QUBOTools.lift_state
+```
+
 ### Underlying Data Structures
 
 ```@docs

--- a/src/interface/form.jl
+++ b/src/interface/form.jl
@@ -72,6 +72,28 @@ Returns the quadratic part of the QUBO form.
 """
 function quadratic_form end
 
+@doc raw"""
+    fix_variables(Φ::AbstractForm, fix::AbstractDict{<:Integer})
+
+Fixes variables in `Φ` to the values supplied by `fix`.
+
+For boolean forms, fixed values must belong to ``\mathbb{B} = \{0, 1\}``.
+For spin forms, fixed values must belong to ``\mathbb{S} = \{-1, 1\}``.
+
+Returns `(Φ_reduced, offset_delta, index_map)`, where `offset_delta` is the
+unscaled amount added to `offset(Φ)` and `index_map` maps each surviving
+original variable index to its dense index in `Φ_reduced`.
+"""
+function fix_variables end
+
+@doc raw"""
+    lift_state(state_reduced, fix, index_map, n)
+
+Reconstructs a full length-`n` state from a reduced state, fixed variable
+values, and the `index_map` returned by [`QUBOTools.fix_variables`](@ref).
+"""
+function lift_state end
+
 
 @doc raw"""
     qubo(args; kws...)

--- a/src/library/form/abstract.jl
+++ b/src/library/form/abstract.jl
@@ -162,12 +162,3 @@ function Base.iterate(Φ::F, state::Integer = 1) where {T,F<:AbstractForm{T}}
         return nothing
     end
 end
-
-function fix_variables(fix::Vector{<:Integer}, Φ::F) where {T,F<:AbstractForm{T}}
-    n = dimension(Φ)
-    L = linear_form(Φ)
-
-    for i in fix
-
-    end
-end

--- a/src/library/form/form.jl
+++ b/src/library/form/form.jl
@@ -69,6 +69,181 @@ function Base.copy(
     )
 end
 
+function fix_variables(
+    Φ::F,
+    fix::AbstractDict{<:Integer},
+) where {T,F<:AbstractForm{T}}
+    n = dimension(Φ)
+    fixed = _fix_variables_normalize(fix, domain(Φ), n, T)
+    index_map = _fix_variables_index_map(n, fixed)
+    m = length(index_map)
+
+    LF = typeof(linear_form(Φ))
+    QF = typeof(quadratic_form(Φ))
+    l = LF(m, linear_size(Φ))
+    q = QF(m, quadratic_size(Φ))
+    offset_delta = zero(T)
+
+    for (i, v) in linear_terms(Φ)
+        if haskey(fixed, i)
+            offset_delta += v * fixed[i]
+        else
+            ii = index_map[i]
+
+            l[ii] = l[ii] + v
+        end
+    end
+
+    for ((i, j), v) in quadratic_terms(Φ)
+        fixed_i = haskey(fixed, i)
+        fixed_j = haskey(fixed, j)
+
+        if fixed_i && fixed_j
+            offset_delta += v * fixed[i] * fixed[j]
+        elseif fixed_i
+            jj = index_map[j]
+
+            l[jj] = l[jj] + v * fixed[i]
+        elseif fixed_j
+            ii = index_map[i]
+
+            l[ii] = l[ii] + v * fixed[j]
+        else
+            ii = index_map[i]
+            jj = index_map[j]
+
+            if ii < jj
+                q[ii, jj] = q[ii, jj] + v
+            else
+                q[jj, ii] = q[jj, ii] + v
+            end
+        end
+    end
+
+    Φ_reduced = Form{T,LF,QF}(
+        m,
+        l,
+        q,
+        scale(Φ),
+        offset(Φ) + offset_delta;
+        sense  = sense(Φ),
+        domain = domain(Φ),
+    )
+
+    return Φ_reduced, offset_delta, index_map
+end
+
+function fix_variables(fix::AbstractVector{<:Integer}, Φ::AbstractForm)
+    throw(
+        ArgumentError(
+            "fix_variables now expects fix_variables(Φ, fix::AbstractDict) " *
+            "with a fixed value for each variable",
+        ),
+    )
+end
+
+function lift_state(
+    state_reduced::AbstractVector,
+    fix::AbstractDict{<:Integer},
+    index_map::AbstractDict{<:Integer,<:Integer},
+    n::Integer,
+)
+    n >= 0 || throw(ArgumentError("state dimension must be nonnegative"))
+
+    fixed = Dict{Int,valtype(fix)}(Int(i) => v for (i, v) in fix)
+    map = Dict{Int,Int}(Int(i) => Int(j) for (i, j) in index_map)
+    m = length(state_reduced)
+
+    _lift_state_validate(fixed, map, Int(n), m)
+
+    U = promote_type(eltype(state_reduced), valtype(fix))
+    state = Vector{U}(undef, Int(n))
+
+    for i in 1:Int(n)
+        if haskey(fixed, i)
+            state[i] = fixed[i]
+        else
+            state[i] = state_reduced[map[i]]
+        end
+    end
+
+    return state
+end
+
+function _fix_variables_normalize(
+    fix::AbstractDict{<:Integer},
+    domain::Domain,
+    n::Integer,
+    ::Type{T},
+) where {T}
+    fixed = sizehint!(Dict{Int,T}(), length(fix))
+
+    for (i, v) in fix
+        1 <= i <= n || throw(ArgumentError("fixed variable index $i is out of range 1:$n"))
+
+        _fix_variables_validate_value(domain, v)
+
+        fixed[Int(i)] = convert(T, v)
+    end
+
+    return fixed
+end
+
+function _fix_variables_validate_value(domain::Domain, value)
+    if domain === BoolDomain
+        value == 0 || value == 1 ||
+            throw(ArgumentError("boolean fixed value $value is not in {0, 1}"))
+    elseif domain === SpinDomain
+        value == -1 || value == 1 ||
+            throw(ArgumentError("spin fixed value $value is not in {-1, 1}"))
+    else
+        throw(ArgumentError("unsupported domain $domain"))
+    end
+
+    return nothing
+end
+
+function _fix_variables_index_map(n::Integer, fixed::AbstractDict)
+    index_map = sizehint!(Dict{Int,Int}(), n - length(fixed))
+    j = 0
+
+    for i in 1:n
+        haskey(fixed, i) && continue
+
+        j += 1
+        index_map[i] = j
+    end
+
+    return index_map
+end
+
+function _lift_state_validate(
+    fixed::AbstractDict{Int},
+    index_map::AbstractDict{Int,Int},
+    n::Integer,
+    m::Integer,
+)
+    seen = Set{Int}()
+
+    for i in keys(fixed)
+        1 <= i <= n || throw(ArgumentError("fixed variable index $i is out of range 1:$n"))
+    end
+
+    for (i, j) in index_map
+        1 <= i <= n || throw(ArgumentError("index_map key $i is out of range 1:$n"))
+        !haskey(fixed, i) || throw(ArgumentError("index_map contains fixed variable $i"))
+        1 <= j <= m || throw(ArgumentError("reduced variable index $j is out of range 1:$m"))
+        j ∉ seen || throw(ArgumentError("index_map contains duplicate reduced index $j"))
+
+        push!(seen, j)
+    end
+
+    length(fixed) + length(index_map) == n ||
+        throw(ArgumentError("fix and index_map must cover exactly $n variables"))
+
+    return nothing
+end
+
 dimension(Φ::Form)      = Φ.n
 linear_form(Φ::Form)    = Φ.L
 quadratic_form(Φ::Form) = Φ.Q

--- a/src/library/form/form.jl
+++ b/src/library/form/form.jl
@@ -229,6 +229,9 @@ function _lift_state_validate(
         1 <= i <= n || throw(ArgumentError("fixed variable index $i is out of range 1:$n"))
     end
 
+    length(index_map) == m ||
+        throw(ArgumentError("reduced state length $m does not match index map length $(length(index_map))"))
+
     for (i, j) in index_map
         1 <= i <= n || throw(ArgumentError("index_map key $i is out of range 1:$n"))
         !haskey(fixed, i) || throw(ArgumentError("index_map contains fixed variable $i"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using Printf
 using Pkg
 using Pkg.Types: PkgError
+using Random
 using SparseArrays
 using Statistics
 using RecipesBase

--- a/test/unit/library/form.jl
+++ b/test/unit/library/form.jl
@@ -95,6 +95,106 @@ function test_form_topology(Φ̄::F, Φ::F, Ψ̄::F, Ψ::F) where {T,F<:QUBOTool
     return nothing
 end
 
+function _fix_variables_form(form_kind::Symbol, domain::QUBOTools.Domain)
+    seed =
+        (form_kind === :dict ? 11 : form_kind === :sparse ? 23 : 37) +
+        (domain === QUBOTools.BoolDomain ? 0 : 100)
+    rng = Random.MersenneTwister(seed)
+    n = 6
+    L = Float64.(rand(rng, -5:5, n))
+    Q = zeros(Float64, n, n)
+
+    for i in 1:n, j in i:n
+        Q[i, j] = rand(rng, -3:3)
+    end
+
+    if form_kind === :dict
+        return QUBOTools.DictForm{Float64}(
+            n,
+            Dict{Int,Float64}(i => L[i] for i in 1:n),
+            Dict{Tuple{Int,Int},Float64}((i, j) => Q[i, j] for i in 1:n for j in i:n),
+            1.5,
+            -2.0;
+            sense = :min,
+            domain,
+        )
+    elseif form_kind === :sparse
+        return QUBOTools.SparseForm{Float64}(n, sparse(L), sparse(Q), 1.5, -2.0; sense = :min, domain)
+    else
+        return QUBOTools.DenseForm{Float64}(n, L, Q, 1.5, -2.0; sense = :min, domain)
+    end
+end
+
+function _fix_variables_values(domain::QUBOTools.Domain)
+    return domain === QUBOTools.BoolDomain ? [0, 1] : [-1, 1]
+end
+
+function _fix_variables_states(values::Vector{Int}, n::Integer)
+    n == 0 && return [Int[]]
+
+    return [
+        [values[1 + ((mask >> (i - 1)) & 1)] for i in 1:n] for
+        mask in 0:(2^n - 1)
+    ]
+end
+
+function test_form_fix_variables()
+    @testset "Variable Fixing" begin
+        for form_kind in (:dict, :sparse, :dense),
+            domain in (QUBOTools.BoolDomain, QUBOTools.SpinDomain)
+
+            @testset "$(form_kind) $(Symbol(domain))" begin
+                Φ = _fix_variables_form(form_kind, domain)
+                n = QUBOTools.dimension(Φ)
+                values = _fix_variables_values(domain)
+                fix = Dict(2 => values[2], 5 => values[1])
+
+                Φ′, offset_delta, index_map = QUBOTools.fix_variables(Φ, fix)
+
+                @test QUBOTools.dimension(Φ′) == n - length(fix)
+                @test QUBOTools.scale(Φ′) == QUBOTools.scale(Φ)
+                @test QUBOTools.offset(Φ′) ≈ QUBOTools.offset(Φ) + offset_delta
+                @test QUBOTools.sense(Φ′) === QUBOTools.sense(Φ)
+                @test QUBOTools.domain(Φ′) === QUBOTools.domain(Φ)
+                @test index_map == Dict(1 => 1, 3 => 2, 4 => 3, 6 => 4)
+
+                for reduced_state in _fix_variables_states(values, QUBOTools.dimension(Φ′))
+                    full_state = QUBOTools.lift_state(reduced_state, fix, index_map, n)
+
+                    @test QUBOTools.value(full_state, Φ) ≈ QUBOTools.value(reduced_state, Φ′)
+                    @test full_state[2] == fix[2]
+                    @test full_state[5] == fix[5]
+                end
+
+                Φ_identity, identity_delta, identity_map =
+                    QUBOTools.fix_variables(Φ, Dict{Int,Int}())
+
+                @test _compare_forms(Φ_identity, Φ)
+                @test iszero(identity_delta)
+                @test identity_map == Dict(i => i for i in 1:n)
+
+                fix_all = Dict(i => values[1 + (i % 2)] for i in 1:n)
+                Φ_empty, _, empty_map = QUBOTools.fix_variables(Φ, fix_all)
+                full_state = [fix_all[i] for i in 1:n]
+
+                @test QUBOTools.dimension(Φ_empty) == 0
+                @test isempty(empty_map)
+                @test QUBOTools.value(Int[], Φ_empty) ≈ QUBOTools.value(full_state, Φ)
+
+                invalid_value = domain === QUBOTools.BoolDomain ? -1 : 0
+
+                @test_throws ArgumentError QUBOTools.fix_variables(Φ, Dict(0 => values[1]))
+                @test_throws ArgumentError QUBOTools.fix_variables(Φ, Dict(n + 1 => values[1]))
+                @test_throws ArgumentError QUBOTools.fix_variables(Φ, Dict(1 => invalid_value))
+                @test_throws ArgumentError QUBOTools.fix_variables([1], Φ)
+                @test_throws ArgumentError QUBOTools.lift_state([values[1]], fix, index_map, n)
+            end
+        end
+    end
+
+    return nothing
+end
+
 function test_form_dict()
     @testset "⋅ Dict" begin
         L̄ = Dict{Int,Float64}(1 => 10.0, 2 => 11.0, 3 => 12.0)
@@ -465,6 +565,7 @@ function test_form()
         test_form_dict()
         test_form_sparse()
         test_form_dense()
+        test_form_fix_variables()
     end
 
     return nothing

--- a/test/unit/library/form.jl
+++ b/test/unit/library/form.jl
@@ -188,6 +188,12 @@ function test_form_fix_variables()
                 @test_throws ArgumentError QUBOTools.fix_variables(Φ, Dict(1 => invalid_value))
                 @test_throws ArgumentError QUBOTools.fix_variables([1], Φ)
                 @test_throws ArgumentError QUBOTools.lift_state([values[1]], fix, index_map, n)
+                @test_throws ArgumentError QUBOTools.lift_state(
+                    fill(values[1], QUBOTools.dimension(Φ′) + 1),
+                    fix,
+                    index_map,
+                    n,
+                )
             end
         end
     end


### PR DESCRIPTION
## Summary

- Implements `fix_variables(form, fix::AbstractDict)` for `AbstractForm` backends by folding fixed linear and quadratic contributions into the reduced form offset and surviving linear terms.
- Adds `lift_state` to reconstruct full states from reduced states, fixed values, and the returned old-to-new index map.
- Documents the breaking signature change in the changelog and lists the new API in the docs.

Closes #99

## Tests

- `julia +1.12 --project=. -e 'using Test, Random, SparseArrays, QUBOTools; include("test/assets/comparison.jl"); include("test/unit/library/form.jl"); test_form_fix_variables()'` passed: 390 variable-fixing tests.
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` passed: 1105 tests.

Local note: the default `julia` launcher is Julia 1.10, but the checked-in manifest is resolved with Julia 1.12; local validation used Julia 1.12. CI still covers the configured Julia 1.10 and latest-stable matrix.

## Downstream Search

- `gh search code fix_variables --repo JuliaQUBO/ToQUBO.jl --json path,repository,url --limit 100`: no references.
- `gh search code fix_variables --repo JuliaQUBO/QUBODrivers.jl --json path,repository,url --limit 100`: no references.
- `gh search code fix_variables --repo JuliaQUBO/QUBOLib.jl --json path,repository,url --limit 100`: no references.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `a3637a0`
- Stacked status: not stacked
- Prerequisite PRs: none
