### PR TITLE
Speed up MOI backend extraction

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -24,6 +24,17 @@ boolean `MOI.ModelLike` parsing through `QUBOTools.Model(moi_model)` so that
 performance work such as issue `#56` is exercised by the benchmark harness on
 the reported QUBO conversion path.
 
+It also includes a dense TSP-style constructor fixture (`tsp/cities=36`) that
+exercises the same public MOI extraction path used by ToQUBO integrations:
+
+```julia
+QUBOTools.Model(moi_model)
+```
+
+The default fixture is sized for pull-request benchmark runtime. To add the
+10,000-variable TSP extraction case (`tsp/cities=100`) to the constructor suite,
+set `QUBOTOOLS_SCALE_BENCHMARKS=true` when running the benchmark commands.
+
 To smoke-test the benchmark harness itself without running the full benchmark,
 use:
 

--- a/benchmark/suites/fixtures.jl
+++ b/benchmark/suites/fixtures.jl
@@ -38,6 +38,76 @@ function benchmark_qubo_data(label::String, n::Int; quadratic_density::Float64)
     return (; rng, variables, linear, quadratic)
 end
 
+function _tsp_variable(variables::Vector{Symbol}, cities::Int, city::Int, step::Int)
+    return variables[(city - 1) * cities + step]
+end
+
+function _add_tsp_quadratic!(
+    quadratic::Dict{Tuple{Symbol,Symbol},Float64},
+    order::Dict{Symbol,Int},
+    u::Symbol,
+    v::Symbol,
+    value::Float64,
+)
+    key = order[u] < order[v] ? (u, v) : (v, u)
+
+    quadratic[key] = get(quadratic, key, 0.0) + value
+
+    return nothing
+end
+
+function benchmark_dense_tsp_qubo_data(label::String, cities::Int; penalty::Float64 = 10.0)
+    cities >= 2 || throw(ArgumentError("cities must be at least 2"))
+
+    rng = MersenneTwister(benchmark_seed(label, cities; quadratic_density = 1.0))
+    variables = [
+        Symbol("x", city, "_", step) for city in 1:cities for step in 1:cities
+    ]
+    order = Dict{Symbol,Int}(variable => i for (i, variable) in enumerate(variables))
+    linear = Dict{Symbol,Float64}(variable => -2.0 * penalty for variable in variables)
+    quadratic = Dict{Tuple{Symbol,Symbol},Float64}()
+
+    sizehint!(quadratic, 2 * cities * cities * (cities - 1))
+
+    for city in 1:cities, step_a in 1:(cities - 1), step_b in (step_a + 1):cities
+        _add_tsp_quadratic!(
+            quadratic,
+            order,
+            _tsp_variable(variables, cities, city, step_a),
+            _tsp_variable(variables, cities, city, step_b),
+            2.0 * penalty,
+        )
+    end
+
+    for step in 1:cities, city_a in 1:(cities - 1), city_b in (city_a + 1):cities
+        _add_tsp_quadratic!(
+            quadratic,
+            order,
+            _tsp_variable(variables, cities, city_a, step),
+            _tsp_variable(variables, cities, city_b, step),
+            2.0 * penalty,
+        )
+    end
+
+    for step in 1:cities
+        next_step = step == cities ? 1 : step + 1
+
+        for city_a in 1:cities, city_b in 1:cities
+            city_a == city_b && continue
+
+            _add_tsp_quadratic!(
+                quadratic,
+                order,
+                _tsp_variable(variables, cities, city_a, step),
+                _tsp_variable(variables, cities, city_b, next_step),
+                1.0 + rand(rng),
+            )
+        end
+    end
+
+    return (; rng, variables, linear, quadratic)
+end
+
 function benchmark_fixture(label::String, n::Int; quadratic_density::Float64)
     data = benchmark_qubo_data(label, n; quadratic_density)
 
@@ -114,6 +184,19 @@ function benchmark_constructor_fixture(label::String, n::Int; quadratic_density:
     )
 end
 
+function benchmark_dense_tsp_constructor_fixture(label::String, cities::Int)
+    data = benchmark_dense_tsp_qubo_data(label, cities)
+    bool_moi_model = benchmark_bool_moi_model(data.variables, data.linear, data.quadratic)
+
+    return (
+        label = label,
+        cities = cities,
+        linear = data.linear,
+        quadratic = data.quadratic,
+        bool_moi_model = bool_moi_model,
+    )
+end
+
 function repeat_last(f::F, repeats::Int) where {F}
     result = f()
 
@@ -134,6 +217,14 @@ function repeat_sum(f::F, repeats::Int) where {F}
     return total
 end
 
+function benchmark_scale_constructor_fixtures()
+    if get(ENV, "QUBOTOOLS_SCALE_BENCHMARKS", "false") == "true"
+        return (benchmark_dense_tsp_constructor_fixture("tsp/cities=100", 100),)
+    else
+        return ()
+    end
+end
+
 function benchmark_fixtures()
     return (
         benchmark_fixture("n=128", 128; quadratic_density = 0.08),
@@ -146,5 +237,7 @@ function benchmark_constructor_fixtures()
         benchmark_constructor_fixture("n=128", 128; quadratic_density = 0.08),
         benchmark_constructor_fixture("n=384", 384; quadratic_density = 0.03),
         benchmark_constructor_fixture("n=2048", 2048; quadratic_density = 0.01),
+        benchmark_dense_tsp_constructor_fixture("tsp/cities=36", 36),
+        benchmark_scale_constructor_fixtures()...,
     )
 end

--- a/benchmark/test/runtests.jl
+++ b/benchmark/test/runtests.jl
@@ -15,6 +15,8 @@ include("../suites/constructors.jl")
 include("../suites/conversions.jl")
 include("../suites/evaluation.jl")
 
+const TSP_EXTRACTION_ALLOCATION_BUDGET = 32 * 1024 * 1024
+
 @testset "Benchmark Fixtures" begin
     @test benchmark_seed("n=128", 128; quadratic_density = 0.08) == 0xe5c9c566
 
@@ -41,6 +43,17 @@ include("../suites/evaluation.jl")
     @test QUBOTools.sense(parsed_model) === QUBOTools.Min
     @test QUBOTools.domain(parsed_model) === QUBOTools.BoolDomain
     @test QUBOTools.value(parsed_model, psi) ≈ QUBOTools.value(dict_model, psi)
+
+    tsp_fixture = benchmark_dense_tsp_constructor_fixture("tsp/cities=12", 12)
+    tsp_model = QUBOTools.Model(tsp_fixture.bool_moi_model)
+    tsp_allocated = @allocated QUBOTools.Model(tsp_fixture.bool_moi_model)
+
+    @test length(tsp_fixture.linear) == tsp_fixture.cities^2
+    @test length(tsp_fixture.quadratic) == 2 * tsp_fixture.cities^2 * (tsp_fixture.cities - 1)
+    @test QUBOTools.dimension(tsp_model) == tsp_fixture.cities^2
+    @test QUBOTools.linear_size(tsp_model) == tsp_fixture.cities^2
+    @test QUBOTools.quadratic_size(tsp_model) == length(tsp_fixture.quadratic)
+    @test tsp_allocated <= TSP_EXTRACTION_ALLOCATION_BUDGET
 end
 
 @testset "Benchmark Suites" begin
@@ -58,6 +71,8 @@ end
 
     @test haskey(suite["constructors"], "n=2048")
     @test haskey(suite["constructors"]["n=2048"], "Model/MOI/bool")
+    @test haskey(suite["constructors"], "tsp/cities=36")
+    @test haskey(suite["constructors"]["tsp/cities=36"], "Model/MOI/bool")
 
     for fixture in fixtures
         conversion_group = suite["conversions"][fixture.label]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,6 +4,18 @@
 
 When extending `QUBOTools`, one might want to implement a method for [`QUBOTools.backend`](@ref).
 
+For MathOptInterface/JuMP integrations, including ToQUBO workflows that expose
+an `MOI.ModelLike` object, the supported public materialization path is:
+
+```julia
+qt_model = QUBOTools.Model(moi_model)
+```
+
+Use `backend` for wrapper types that already own or can return a
+`QUBOTools.AbstractModel`; use `QUBOTools.Model(moi_model)` when the source is an
+MOI model that needs to be converted into QUBOTools' sparse in-memory
+representation.
+
 ```@docs
 QUBOTools.backend
 ```

--- a/ext/QUBOTools_MOI/QUBOTools_MOI.jl
+++ b/ext/QUBOTools_MOI/QUBOTools_MOI.jl
@@ -3,6 +3,8 @@ module QUBOTools_MOI
 import QUBOTools
 import MathOptInterface as MOI
 
+using SparseArrays: dropzeros!, sparse, sparsevec
+
 const MOIU    = MOI.Utilities
 const VI      = MOI.VariableIndex
 const CI{F,S} = MOI.ConstraintIndex{F,S}

--- a/ext/QUBOTools_MOI/model_parser.jl
+++ b/ext/QUBOTools_MOI/model_parser.jl
@@ -82,7 +82,8 @@ function _parse_moi_model(::Type{T}, model::MOI.ModelLike) where {T}
         qubo_parsing_error("The provided model is not unconstrained.\n")
     end
 
-    V = Set{VI}(MOI.get(model, MOI.ListOfVariableIndices()))
+    variables = MOI.get(model, MOI.ListOfVariableIndices())
+    V = Set{VI}(variables)
     𝔹 = Set{VI}()
     𝕊 = Set{VI}()
 
@@ -131,59 +132,186 @@ function _parse_moi_model(::Type{T}, model::MOI.ModelLike) where {T}
         if 𝔹 != V
             qubo_parsing_error("Not all variables in the given model are boolean.\n")
         else
-            return _extract_bool_model(T, model, V, fixed)
+            return _extract_bool_model(T, model, variables, fixed)
         end
     else # isempty(𝔹) # Ising model?
         if 𝕊 != V
             qubo_parsing_error("Not all variables in the given model are spin.\n")
         else
-            return _extract_spin_model(T, model, V, fixed)
+            return _extract_spin_model(T, model, variables, fixed)
         end
     end
 end
 
-function _extract_bool_model(::Type{T}, model::MOI.ModelLike, V::Set{VI}, fixed::Dict{VI,T}) where {T}
-    L = Dict{VI,T}(xi => zero(T) for xi ∈ V if !haskey(fixed, xi))
-    Q = Dict{Tuple{VI,VI},T}()
+function _remaining_variable_map(variables::AbstractVector{VI}, fixed::Dict{VI,T}) where {T}
+    if isempty(fixed)
+        return QUBOTools.VariableMap{VI}(variables)
+    else
+        return QUBOTools.VariableMap{VI}(VI[xi for xi in variables if !haskey(fixed, xi)])
+    end
+end
 
-    β = zero(T)
+function _append_linear_term!(
+    linear_indices::Vector{Int},
+    linear_values::Vector{T},
+    variable_index::Dict{VI,Int},
+    xi::VI,
+    ci,
+) where {T}
+    push!(linear_indices, variable_index[xi])
+    push!(linear_values, ci)
+
+    return nothing
+end
+
+function _append_quadratic_term!(
+    quadratic_rows::Vector{Int},
+    quadratic_cols::Vector{Int},
+    quadratic_values::Vector{T},
+    variable_index::Dict{VI,Int},
+    xi::VI,
+    xj::VI,
+    cij,
+) where {T}
+    i = variable_index[xi]
+    j = variable_index[xj]
+
+    if i < j
+        push!(quadratic_rows, i)
+        push!(quadratic_cols, j)
+    else
+        push!(quadratic_rows, j)
+        push!(quadratic_cols, i)
+    end
+
+    push!(quadratic_values, cij)
+
+    return nothing
+end
+
+function _add_linear_or_offset!(
+    linear_indices::Vector{Int},
+    linear_values::Vector{T},
+    variable_index::Dict{VI,Int},
+    fixed::Dict{VI,T},
+    β::T,
+    xi::VI,
+    ci,
+) where {T}
+    if haskey(fixed, xi)
+        return β + fixed[xi] * ci
+    else
+        _append_linear_term!(linear_indices, linear_values, variable_index, xi, ci)
+
+        return β
+    end
+end
+
+function _finalize_moi_model(
+    ::Type{T},
+    variable_map::QUBOTools.VariableMap{VI},
+    linear_indices::Vector{Int},
+    linear_values::Vector{T},
+    quadratic_rows::Vector{Int},
+    quadratic_cols::Vector{Int},
+    quadratic_values::Vector{T},
+    β::T;
+    sense::QUBOTools.Sense,
+    domain::Symbol,
+) where {T}
+    n = length(variable_map)
+
+    L = sparsevec(linear_indices, linear_values, n)
+    Q = sparse(quadratic_rows, quadratic_cols, quadratic_values, n, n)
+
+    dropzeros!(L)
+    dropzeros!(Q)
+
+    form = QUBOTools.Form{T}(
+        n,
+        QUBOTools.SparseLinearForm{T}(L),
+        QUBOTools.SparseQuadraticForm{T}(Q),
+        one(T),
+        β;
+        sense,
+        domain,
+    )
+
+    return QUBOTools.Model{VI,T,Int}(variable_map, form)
+end
+
+function _extract_bool_model(
+    ::Type{T},
+    model::MOI.ModelLike,
+    variables::AbstractVector{VI},
+    fixed::Dict{VI,T},
+) where {T}
+    variable_map = _remaining_variable_map(variables, fixed)
+    variable_index = variable_map.map
 
     F = MOI.get(model, MOI.ObjectiveFunctionType())
     f = MOI.get(model, MOI.ObjectiveFunction{F}())
 
+    affine_count = F <: SQF ? length(f.affine_terms) : F <: SAF ? length(f.terms) : 1
+    quadratic_count = F <: SQF ? length(f.quadratic_terms) : 0
+
+    linear_indices = Int[]
+    linear_values = T[]
+    sizehint!(linear_indices, affine_count + quadratic_count)
+    sizehint!(linear_values, affine_count + quadratic_count)
+
+    quadratic_rows = Int[]
+    quadratic_cols = Int[]
+    quadratic_values = T[]
+    sizehint!(quadratic_rows, quadratic_count)
+    sizehint!(quadratic_cols, quadratic_count)
+    sizehint!(quadratic_values, quadratic_count)
+
+    β = zero(T)
+
     if F <: VI
+        ci = one(T)
+
         if haskey(fixed, f)
-            β += fixed[f]
+            β += fixed[f] * ci
         else
-            L[f] += one(T)
+            _append_linear_term!(linear_indices, linear_values, variable_index, f, ci)
         end
     elseif F <: SAF
         for a in f.terms
-            ci = a.coefficient
+            ci = convert(T, a.coefficient)
             xi = a.variable
 
-            if haskey(fixed, xi)
-                β += fixed[xi] * ci
-            else
-                L[xi] += ci
-            end
+            β = _add_linear_or_offset!(
+                linear_indices,
+                linear_values,
+                variable_index,
+                fixed,
+                β,
+                xi,
+                ci,
+            )
         end
 
-        β += f.constant
+        β += convert(T, f.constant)
     elseif F <: SQF
         for a in f.affine_terms
-            ci = a.coefficient
+            ci = convert(T, a.coefficient)
             xi = a.variable
 
-            if haskey(fixed, xi)
-                β += fixed[xi] * ci
-            else
-                L[xi] += ci
-            end
+            β = _add_linear_or_offset!(
+                linear_indices,
+                linear_values,
+                variable_index,
+                fixed,
+                β,
+                xi,
+                ci,
+            )
         end
 
         for a in f.quadratic_terms
-            cij = a.coefficient
+            cij = convert(T, a.coefficient)
             xi = a.variable_1
             xj = a.variable_2
 
@@ -195,73 +323,134 @@ function _extract_bool_model(::Type{T}, model::MOI.ModelLike, V::Set{VI}, fixed:
                 if haskey(fixed, xi)
                     β += fixed[xi] * cij / 2
                 else
-                    L[xi] += cij / 2
+                    _append_linear_term!(
+                        linear_indices,
+                        linear_values,
+                        variable_index,
+                        xi,
+                        cij / 2,
+                    )
                 end
             elseif haskey(fixed, xi) && haskey(fixed, xj)
                 β += fixed[xi] * fixed[xj] * cij
             elseif haskey(fixed, xi)
-                L[xj] += fixed[xi] * cij
+                _append_linear_term!(
+                    linear_indices,
+                    linear_values,
+                    variable_index,
+                    xj,
+                    fixed[xi] * cij,
+                )
             elseif haskey(fixed, xj)
-                L[xi] += fixed[xj] * cij
+                _append_linear_term!(
+                    linear_indices,
+                    linear_values,
+                    variable_index,
+                    xi,
+                    fixed[xj] * cij,
+                )
             else
-                Q[(xi, xj)] = get(Q, (xi, xj), zero(T)) + cij
+                _append_quadratic_term!(
+                    quadratic_rows,
+                    quadratic_cols,
+                    quadratic_values,
+                    variable_index,
+                    xi,
+                    xj,
+                    cij,
+                )
             end
         end
 
-        β += f.constant
+        β += convert(T, f.constant)
     end
 
-    return QUBOTools.Model{VI,T,Int}(
-        L,
-        Q;
-        offset = β,
-        sense  = QUBOTools.sense(MOI.get(model, MOI.ObjectiveSense())),
+    return _finalize_moi_model(
+        T,
+        variable_map,
+        linear_indices,
+        linear_values,
+        quadratic_rows,
+        quadratic_cols,
+        quadratic_values,
+        β;
+        sense = QUBOTools.sense(MOI.get(model, MOI.ObjectiveSense())),
         domain = :bool,
     )
 end
 
-function _extract_spin_model(::Type{T}, model::MOI.ModelLike, V::Set{VI}, fixed::Dict{VI,T}) where {T}
-    L = Dict{VI,T}(xi => zero(T) for xi ∈ V if !haskey(fixed, xi))
-    Q = Dict{Tuple{VI,VI},T}()
-
-    β = zero(T)
+function _extract_spin_model(
+    ::Type{T},
+    model::MOI.ModelLike,
+    variables::AbstractVector{VI},
+    fixed::Dict{VI,T},
+) where {T}
+    variable_map = _remaining_variable_map(variables, fixed)
+    variable_index = variable_map.map
 
     F = MOI.get(model, MOI.ObjectiveFunctionType())
     f = MOI.get(model, MOI.ObjectiveFunction{F}())
 
+    affine_count = F <: SQF ? length(f.affine_terms) : F <: SAF ? length(f.terms) : 1
+    quadratic_count = F <: SQF ? length(f.quadratic_terms) : 0
+
+    linear_indices = Int[]
+    linear_values = T[]
+    sizehint!(linear_indices, affine_count + quadratic_count)
+    sizehint!(linear_values, affine_count + quadratic_count)
+
+    quadratic_rows = Int[]
+    quadratic_cols = Int[]
+    quadratic_values = T[]
+    sizehint!(quadratic_rows, quadratic_count)
+    sizehint!(quadratic_cols, quadratic_count)
+    sizehint!(quadratic_values, quadratic_count)
+
+    β = zero(T)
+
     if F <: VI
+        ci = one(T)
+
         if haskey(fixed, f)
-            β += fixed[f]
+            β += fixed[f] * ci
         else
-            L[f] += one(T)
+            _append_linear_term!(linear_indices, linear_values, variable_index, f, ci)
         end
     elseif F <: SAF
         for a in f.terms
-            ci = a.coefficient
+            ci = convert(T, a.coefficient)
             xi = a.variable
 
-            if haskey(fixed, xi)
-                β += fixed[xi] * ci
-            else
-                L[xi] += ci
-            end
+            β = _add_linear_or_offset!(
+                linear_indices,
+                linear_values,
+                variable_index,
+                fixed,
+                β,
+                xi,
+                ci,
+            )
         end
 
-        β += f.constant
+        β += convert(T, f.constant)
     elseif F <: SQF
         for a in f.affine_terms
-            ci = a.coefficient
+            ci = convert(T, a.coefficient)
             xi = a.variable
 
-            if haskey(fixed, xi)
-                β += fixed[xi] * ci
-            else
-                L[xi] += ci
-            end
+            β = _add_linear_or_offset!(
+                linear_indices,
+                linear_values,
+                variable_index,
+                fixed,
+                β,
+                xi,
+                ci,
+            )
         end
 
         for a in f.quadratic_terms
-            cij = a.coefficient
+            cij = convert(T, a.coefficient)
             xi = a.variable_1
             xj = a.variable_2
 
@@ -274,22 +463,47 @@ function _extract_spin_model(::Type{T}, model::MOI.ModelLike, V::Set{VI}, fixed:
             elseif haskey(fixed, xi) && haskey(fixed, xj)
                 β += fixed[xi] * fixed[xj] * cij
             elseif haskey(fixed, xi)
-                L[xj] += fixed[xi] * cij
+                _append_linear_term!(
+                    linear_indices,
+                    linear_values,
+                    variable_index,
+                    xj,
+                    fixed[xi] * cij,
+                )
             elseif haskey(fixed, xj)
-                L[xi] += fixed[xj] * cij
+                _append_linear_term!(
+                    linear_indices,
+                    linear_values,
+                    variable_index,
+                    xi,
+                    fixed[xj] * cij,
+                )
             else
-                Q[(xi, xj)] = get(Q, (xi, xj), zero(T)) + cij
+                _append_quadratic_term!(
+                    quadratic_rows,
+                    quadratic_cols,
+                    quadratic_values,
+                    variable_index,
+                    xi,
+                    xj,
+                    cij,
+                )
             end
         end
 
-        β += f.constant
+        β += convert(T, f.constant)
     end
 
-    return QUBOTools.Model{VI,T,Int}(
-        L,
-        Q;
-        offset = β,
-        sense  = QUBOTools.sense(MOI.get(model, MOI.ObjectiveSense())),
+    return _finalize_moi_model(
+        T,
+        variable_map,
+        linear_indices,
+        linear_values,
+        quadratic_rows,
+        quadratic_cols,
+        quadratic_values,
+        β;
+        sense = QUBOTools.sense(MOI.get(model, MOI.ObjectiveSense())),
         domain = :spin,
     )
 end


### PR DESCRIPTION
## Summary

- Build sparse QUBOTools forms directly from MOI objective terms instead of first materializing large linear/quadratic dictionaries.
- Add a dense TSP-style constructor benchmark fixture, with a PR-safe default and an opt-in 10,000-variable scale case via `QUBOTOOLS_SCALE_BENCHMARKS=true`.
- Document `QUBOTools.Model(moi_model)` as the supported public MOI/ToQUBO materialization path.

## Tests

- `julia --project=benchmark benchmark/test/runtests.jl` - passed.
- `julia +1.12 --project=. -e 'import Pkg; Pkg.test()'` - passed.
- `julia --project=benchmark -e '... benchmark_dense_tsp_constructor_fixture("tsp/cities=100", 100) ...'` - passed; 10,000 variables, 1,980,000 quadratic terms, 0.887258424 seconds, 209,003,768 bytes allocated.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `089966e`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #101
