### PR TITLE
Add opt-in scale-test tier

### DIFF
--- a/.github/workflows/scale-tests.yml
+++ b/.github/workflows/scale-tests.yml
@@ -1,0 +1,29 @@
+name: Scale Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 8 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  scale:
+    name: Julia 1 - ubuntu-latest - x64 - scale
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      QUBOTOOLS_SCALE_TESTS: true
+      QUBOTOOLS_SCALE_MAX_N: 100000
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1"
+          arch: x64
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Run scale tests
+        run: julia --project=. -e 'using Pkg; Pkg.test(; test_args = ["scale-only"])'

--- a/docs/build.jl
+++ b/docs/build.jl
@@ -30,6 +30,7 @@ const DOCS_PAGES = [
         "File Formats"             => "manual/5-formats.md",
         "Solutions"                => "manual/6-solutions.md",
         "Analysis"                 => "manual/7-analysis.md",
+        "Scalability"              => "manual/8-scalability.md",
     ],
     "Formats" => [
         "BQPJSON"  => "formats/bqpjson.md",

--- a/docs/src/manual/8-scalability.md
+++ b/docs/src/manual/8-scalability.md
@@ -1,0 +1,54 @@
+# Scalability
+
+QUBOTools keeps the default test suite focused on small fixtures so that
+`Pkg.test("QUBOTools")` remains suitable for pull requests and local
+development. Large generated instances are covered by an opt-in scale-test tier.
+
+Run the full scale tier from the repository root with:
+
+```bash
+QUBOTOOLS_SCALE_TESTS=true julia --project=. -e 'using Pkg; Pkg.test(; test_args = ["scale-only"])'
+```
+
+To run a smaller local smoke pass, cap the maximum generated dimension:
+
+```bash
+QUBOTOOLS_SCALE_TESTS=true QUBOTOOLS_SCALE_MAX_N=5000 julia --project=. -e 'using Pkg; Pkg.test(; test_args = ["scale-only"])'
+```
+
+The scheduled GitHub Actions scale job runs generated sparse cases at
+`n = 1000`, `5000`, `20000`, and `100000` with average degree 4. These cases
+exercise:
+
+- sparse model construction from generated linear and quadratic dictionaries;
+- dense Sherrington-Kirkpatrick and Wishart synthesis smoke cases at `n = 1000`;
+- energy evaluation on random states;
+- sparse, dictionary, and dense form agreement at `n = 1000`;
+- sparse and dictionary form agreement at larger sizes;
+- QUBin round-trips at every scale-test size;
+- QUBO text round-trips at `n = 20000` and `n = 100000`;
+- exact Float64 preservation for a portfolio-like numerical range from
+  `1e-3` through `2e10`;
+- `SampleSet` construction and duplicate-state merging with large states.
+
+## Practical Envelope
+
+Sparse forms are the intended representation for large generated and archived
+instances. A sparse quadratic form is backed by Julia's `SparseMatrixCSC`, which
+stores one row index and one value per nonzero term plus one column pointer per
+variable. With 64-bit indices and `Float64` coefficients, the dominant storage
+is about 16 bytes per quadratic nonzero plus about 8 bytes per variable for
+column pointers. Sparse linear terms add about 16 bytes per nonzero. Temporary
+construction dictionaries and I/O buffers require additional memory, so peak
+memory is higher than the final sparse form.
+
+Dense forms use an `n x n` `Float64` matrix for quadratic terms. That is about
+`8n^2` bytes before Julia array overhead, so dense forms are practical only for
+small cross-checks. The scale tier limits dense correctness checks to
+`n = 1000`.
+
+The current scheduled envelope is sparse instances with 100000 variables and
+about 200000 quadratic terms. Denser QOBLib-style archives with millions of
+terms should be tested with a dedicated benchmark or data-validation workflow so
+their time and memory budgets can be reviewed separately from regular package
+tests.

--- a/src/library/form/sparse.jl
+++ b/src/library/form/sparse.jl
@@ -6,11 +6,18 @@ struct SparseLinearForm{T} <: AbstractLinearForm{T}
 end
 
 function SparseLinearForm{T}(n::Integer, lf::LF) where {T,S,LF<:AbstractLinearForm{S}}
-    data = spzeros(T, n)
+    indices = Int[]
+    values = T[]
+    sizehint!(indices, linear_size(lf))
+    sizehint!(values, linear_size(lf))
 
     for (i, v) in linear_terms(lf)
-        data[i] = convert(T, v)
+        push!(indices, i)
+        push!(values, convert(T, v))
     end
+
+    data = sparsevec(indices, values, n)
+    dropzeros!(data)
 
     return SparseLinearForm{T}(data)
 end
@@ -55,11 +62,21 @@ struct SparseQuadraticForm{T} <: AbstractQuadraticForm{T}
 end
 
 function SparseQuadraticForm{T}(n::Integer, qf::QF) where {T,S,QF<:AbstractQuadraticForm{S}}
-    data = zeros(T, n, n)
+    rows = Int[]
+    cols = Int[]
+    values = T[]
+    sizehint!(rows, quadratic_size(qf))
+    sizehint!(cols, quadratic_size(qf))
+    sizehint!(values, quadratic_size(qf))
 
     for ((i, j), v) in quadratic_terms(qf)
-        data[i, j] = convert(T, v)
+        push!(rows, i)
+        push!(cols, j)
+        push!(values, convert(T, v))
     end
+
+    data = sparse(rows, cols, values, n, n)
+    dropzeros!(data)
 
     return SparseQuadraticForm{T}(data)
 end

--- a/src/library/format/qubo/parser.jl
+++ b/src/library/format/qubo/parser.jl
@@ -49,7 +49,10 @@ function _parse_entry!(
     L = data[:linear_terms]
     Q = data[:quadratic_terms]
 
-    m = match(r"^([0-9]+)\s+([0-9]+)\s+([+-]?([0-9]*[.])?[0-9]+)$", line)
+    m = match(
+        r"^([0-9]+)\s+([0-9]+)\s+([+-]?(([0-9]+([.][0-9]*)?)|([.][0-9]+))([eE][+-]?[0-9]+)?)$",
+        line,
+    )
 
     if isnothing(m)
         return false
@@ -72,7 +75,10 @@ function _parse_entry!(data::Dict{Symbol,Any}, line::AbstractString, ::Format{:q
     L = data[:linear_terms]
     Q = data[:quadratic_terms]
 
-    m = match(r"^([0-9]+)\s+([0-9]+)\s+([+-]?([0-9]*[.])?[0-9]+)$", line)
+    m = match(
+        r"^([0-9]+)\s+([0-9]+)\s+([+-]?(([0-9]+([.][0-9]*)?)|([.][0-9]+))([eE][+-]?[0-9]+)?)$",
+        line,
+    )
 
     if isnothing(m)
         return false

--- a/src/library/format/rudy/format.jl
+++ b/src/library/format/rudy/format.jl
@@ -72,6 +72,26 @@ function parse_line!(data::RUDY_DATA{T}, line::AbstractString, fmt::Format{:rudy
     end
 end
 
+function QUBOTools.write_model(io::IO, model::QUBOTools.AbstractModel, fmt::QUBOTools.Format{:rudy})
+    Φ = QUBOTools.form(model, :sparse; domain = fmt[:domain])
+    α = QUBOTools.scale(Φ)
+
+    println(io, "# Constant term of objective = $(α * QUBOTools.offset(Φ))")
+    println(io, "# Diagonal terms")
+
+    for (i, h) in QUBOTools.linear_terms(Φ)
+        println(io, "$(i - 1) $(i - 1) $(α * h)")
+    end
+
+    println(io, "# Off-Diagonal terms")
+
+    for ((i, j), J) in QUBOTools.quadratic_terms(Φ)
+        println(io, "$(i - 1) $(j - 1) $(α * J)")
+    end
+
+    return nothing
+end
+
 function QUBOTools.read_model(io::IO, fmt::QUBOTools.Format{:rudy})
     data = RUDY_DATA{Float64}(; domain = QUBOTools.domain(fmt[:domain]))
 

--- a/src/library/format/rudy/format.jl
+++ b/src/library/format/rudy/format.jl
@@ -38,7 +38,7 @@ function parse_comment!(data, line::AbstractString, ::Format{:rudy})
     end
 
     # Constant term of objective = 66363.47
-    let m = match(r"^# Constant term of objective = ([+-]?([0-9]+([.][0-9]*)?|[.][0-9]+))$", line)
+    let m = match(r"^# Constant term of objective = ([+-]?(([0-9]+([.][0-9]*)?)|([.][0-9]+))([eE][+-]?[0-9]+)?)$", line)
         if !isnothing(m)
             data.offset = parse(Float64, m[1])
 
@@ -52,7 +52,7 @@ end
 function parse_line!(data::RUDY_DATA{T}, line::AbstractString, fmt::Format{:rudy}) where {T}
     startswith(line, "#") && return parse_comment!(data, line, fmt)
     
-    let m = match(r"^(\d+)\s+(\d+)\s+([+-]?([0-9]+([.][0-9]*)?|[.][0-9]+))$", line)
+    let m = match(r"^(\d+)\s+(\d+)\s+([+-]?(([0-9]+([.][0-9]*)?)|([.][0-9]+))([eE][+-]?[0-9]+)?)$", line)
         if !isnothing(m)
             # Note: rudy is 0-indexed!
             i = parse(Int, m[1]) + 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,14 +28,26 @@ const QUBOModel     = QUBOTools_MOI.QUBOModel
 const NumberOfReads = QUBOTools_MOI.NumberOfReads
 
 const __TEST_PATH__ = @__DIR__
+const __SCALE_ONLY__ = "scale-only" in ARGS
+
+function _scale_tests_requested()
+    return lowercase(get(ENV, "QUBOTOOLS_SCALE_TESTS", "false")) in
+           Set(["1", "true", "yes", "on"])
+end
 
 # Include assets
 include("assets/comparison.jl")
 include("assets/foreign_tests.jl")
 
 # Include test functions
-include("unit/unit.jl")
-include("integration/integration.jl")
+if __SCALE_ONLY__ || _scale_tests_requested()
+    include("scale/scale.jl")
+end
+
+if !__SCALE_ONLY__
+    include("unit/unit.jl")
+    include("integration/integration.jl")
+end
 
 function test_main()
     @testset "◈ ◈ ◈ QUBOTools.jl Test Suite ◈ ◈ ◈" verbose = true begin
@@ -46,4 +58,12 @@ function test_main()
     return nothing
 end
 
-test_main() # Here we go!
+if __SCALE_ONLY__
+    test_scale()
+else
+    test_main() # Here we go!
+
+    if _scale_tests_requested()
+        test_scale()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,19 +30,12 @@ const NumberOfReads = QUBOTools_MOI.NumberOfReads
 const __TEST_PATH__ = @__DIR__
 const __SCALE_ONLY__ = "scale-only" in ARGS
 
-function _scale_tests_requested()
-    return lowercase(get(ENV, "QUBOTOOLS_SCALE_TESTS", "false")) in
-           Set(["1", "true", "yes", "on"])
-end
-
 # Include assets
 include("assets/comparison.jl")
 include("assets/foreign_tests.jl")
 
 # Include test functions
-if __SCALE_ONLY__ || _scale_tests_requested()
-    include("scale/scale.jl")
-end
+include("scale/scale.jl")
 
 if !__SCALE_ONLY__
     include("unit/unit.jl")
@@ -63,7 +56,7 @@ if __SCALE_ONLY__
 else
     test_main() # Here we go!
 
-    if _scale_tests_requested()
+    if _scale_tests_enabled()
         test_scale()
     end
 end

--- a/test/scale/runtests.jl
+++ b/test/scale/runtests.jl
@@ -1,0 +1,11 @@
+using Test
+using Random
+using QUBOTools
+
+include("scale.jl")
+
+if _scale_tests_enabled()
+    test_scale()
+else
+    @info "Set QUBOTOOLS_SCALE_TESTS=true to run the scale-test tier"
+end

--- a/test/scale/scale.jl
+++ b/test/scale/scale.jl
@@ -1,0 +1,338 @@
+const _SCALE_TRUE_VALUES = Set(["1", "true", "yes", "on"])
+
+struct _ScaleCase
+    n::Int
+    avg_degree::Int
+    construction_seconds::Float64
+    construction_mib::Float64
+    evaluation_seconds::Float64
+    evaluation_mib::Float64
+    qubin_seconds::Float64
+    qubin_mib::Float64
+    qubo_seconds::Float64
+    qubo_mib::Float64
+end
+
+function _scale_tests_enabled()
+    return lowercase(get(ENV, "QUBOTOOLS_SCALE_TESTS", "false")) in _SCALE_TRUE_VALUES
+end
+
+function _scale_env_int(name::AbstractString, default::Int)
+    value = get(ENV, name, string(default))
+
+    parsed = tryparse(Int, value)
+    isnothing(parsed) && error("$(name) must be an integer, got '$(value)'")
+
+    return parsed
+end
+
+function _scale_cases()
+    max_n = _scale_env_int("QUBOTOOLS_SCALE_MAX_N", 100_000)
+    cases = _ScaleCase[
+        _ScaleCase(1_000, 4, 10.0, 512.0, 2.0, 128.0, 20.0, 768.0, 20.0, 768.0),
+        _ScaleCase(5_000, 4, 10.0, 512.0, 2.0, 128.0, 20.0, 768.0, 20.0, 768.0),
+        _ScaleCase(20_000, 4, 20.0, 768.0, 5.0, 256.0, 60.0, 1_024.0, 60.0, 1_024.0),
+        _ScaleCase(100_000, 4, 60.0, 1_536.0, 10.0, 512.0, 180.0, 2_048.0, 180.0, 2_048.0),
+    ]
+
+    return filter(case -> case.n <= max_n, cases)
+end
+
+function _scale_sparse_er_model(n::Int; avg_degree::Int, seed::Int)
+    rng = Random.MersenneTwister(seed)
+    variables = Set{Int}(1:n)
+    linear_terms = sizehint!(Dict{Int,Float64}(), n)
+
+    for i in 1:n
+        linear_terms[i] = randn(rng)
+    end
+
+    target_edges = max(1, (n * avg_degree) ÷ 2)
+    quadratic_terms = sizehint!(Dict{Tuple{Int,Int},Float64}(), target_edges)
+
+    while length(quadratic_terms) < target_edges
+        i = rand(rng, 1:(n - 1))
+        j = rand(rng, (i + 1):n)
+
+        quadratic_terms[(i, j)] = randn(rng)
+    end
+
+    return QUBOTools.Model{Int,Float64,Int}(
+        variables,
+        linear_terms,
+        quadratic_terms;
+        sense = :min,
+        domain = :bool,
+        metadata = Dict{String,Any}(
+            "scale_test" => true,
+            "generator" => "sparse_er",
+            "avg_degree" => avg_degree,
+        ),
+    )
+end
+
+function _scale_portfolio_like_model()
+    magnitudes = [
+        1.0e-3,
+        -2.5e-2,
+        3.75e-1,
+        -4.5,
+        6.25e3,
+        -8.0e6,
+        1.25e9,
+        -2.0e10,
+    ]
+    linear_terms = Dict{Int,Float64}(i => magnitudes[i] for i in eachindex(magnitudes))
+    quadratic_terms = Dict{Tuple{Int,Int},Float64}(
+        (1, 8) => 2.0e10,
+        (2, 7) => -1.0e-3,
+        (3, 6) => 5.125e5,
+        (4, 5) => -7.25e8,
+    )
+
+    return QUBOTools.Model{Int,Float64,Int}(
+        Set{Int}(1:length(magnitudes)),
+        linear_terms,
+        quadratic_terms;
+        offset = 1.0e-3,
+        sense = :min,
+        domain = :bool,
+        metadata = Dict{String,Any}("scale_test" => "numerical_range"),
+    )
+end
+
+function _scale_timed(f::Function, label::AbstractString, seconds::Real, mib::Real)
+    result = @timed f()
+
+    @info label time = result.time mib = result.bytes / 2.0^20
+    @test result.time <= seconds
+    @test result.bytes <= mib * 2.0^20
+
+    return result.value
+end
+
+function _scale_with_temp_path(f::Function, suffix::AbstractString)
+    path = "$(tempname()).$(suffix)"
+
+    try
+        return f(path)
+    finally
+        rm(path; force = true)
+    end
+end
+
+function _scale_roundtrip(model, suffix::AbstractString)
+    return _scale_with_temp_path(suffix) do path
+        QUBOTools.write_model(path, model)
+
+        return QUBOTools.read_model(path)
+    end
+end
+
+function _scale_linear_terms(model)
+    return Dict{Int,Float64}(QUBOTools.linear_terms(model))
+end
+
+function _scale_quadratic_terms(model)
+    return Dict{Tuple{Int,Int},Float64}(QUBOTools.quadratic_terms(model))
+end
+
+function _scale_assert_same_terms(src::AbstractDict{K,T}, dst::AbstractDict{K,T}) where {K,T}
+    @test keys(src) == keys(dst)
+
+    for key in keys(src)
+        @test dst[key] ≈ src[key]
+    end
+
+    return nothing
+end
+
+function _scale_assert_same_model(src, dst; exact::Bool = false)
+    @test QUBOTools.dimension(dst) == QUBOTools.dimension(src)
+    @test QUBOTools.variables(dst) == QUBOTools.variables(src)
+    @test QUBOTools.metadata(dst) == QUBOTools.metadata(src)
+    @test QUBOTools.sense(dst) === QUBOTools.sense(src)
+    @test QUBOTools.domain(dst) === QUBOTools.domain(src)
+
+    if exact
+        @test QUBOTools.scale(dst) == QUBOTools.scale(src)
+        @test QUBOTools.offset(dst) == QUBOTools.offset(src)
+        @test _scale_linear_terms(dst) == _scale_linear_terms(src)
+        @test _scale_quadratic_terms(dst) == _scale_quadratic_terms(src)
+    else
+        @test QUBOTools.scale(dst) ≈ QUBOTools.scale(src)
+        @test QUBOTools.offset(dst) ≈ QUBOTools.offset(src)
+        _scale_assert_same_terms(_scale_linear_terms(src), _scale_linear_terms(dst))
+        _scale_assert_same_terms(_scale_quadratic_terms(src), _scale_quadratic_terms(dst))
+    end
+
+    return nothing
+end
+
+function _scale_random_states(n::Int, count::Int; seed::Int)
+    rng = Random.MersenneTwister(seed)
+
+    return [rand(rng, 0:1, n) for _ in 1:count]
+end
+
+function _scale_assert_value_preserved(src, dst, states)
+    for state in states
+        @test QUBOTools.value(dst, state) ≈ QUBOTools.value(src, state)
+    end
+
+    return nothing
+end
+
+function _scale_warmup()
+    model = _scale_sparse_er_model(32; avg_degree = 4, seed = 41)
+    state = first(_scale_random_states(32, 1; seed = 42))
+
+    QUBOTools.value(model, state)
+    QUBOTools.form(model, :dict)
+    QUBOTools.form(model, :dense)
+    _scale_roundtrip(model, "qb")
+    _scale_roundtrip(model, "qubo")
+
+    return nothing
+end
+
+function _scale_test_form_correctness(model, states; include_dense::Bool)
+    sparse_form = QUBOTools.form(model)
+    dict_form = QUBOTools.form(model, :dict)
+
+    for state in states
+        @test QUBOTools.value(state, dict_form) ≈ QUBOTools.value(state, sparse_form)
+    end
+
+    if include_dense
+        dense_form = QUBOTools.form(model, :dense)
+
+        for state in states
+            @test QUBOTools.value(state, dense_form) ≈ QUBOTools.value(state, sparse_form)
+        end
+    end
+
+    return nothing
+end
+
+function _scale_test_sampleset(model, states)
+    repeated = [first(states), copy(first(states))]
+    samples = QUBOTools.SampleSet{Float64,Int}(model, repeated)
+
+    @test length(samples) == 1
+    @test QUBOTools.dimension(samples) == QUBOTools.dimension(model)
+    @test QUBOTools.reads(first(samples)) == 2
+
+    return nothing
+end
+
+function _scale_test_synthesis_generators()
+    @testset "synthesis generators" begin
+        generators = [
+            ("Sherrington-Kirkpatrick", QUBOTools.SherringtonKirkpatrick(1_000), 10.0, 1_024.0),
+            ("Wishart", QUBOTools.Wishart(1_000, 4), 10.0, 1_536.0),
+        ]
+
+        for (label, problem, seconds, mib) in generators
+            model = _scale_timed(label, seconds, mib) do
+                @test_logs (:warn, r"Depraction Warning") QUBOTools.generate(
+                    Random.MersenneTwister(3000),
+                    problem,
+                )
+            end
+
+            @test QUBOTools.dimension(model) == 1_000
+            @test QUBOTools.quadratic_size(model) == 499_500
+
+            states = _scale_random_states(1_000, 2; seed = 3100)
+            _scale_test_form_correctness(model, states; include_dense = false)
+        end
+    end
+
+    return nothing
+end
+
+function _scale_test_case(case::_ScaleCase)
+    @testset "n=$(case.n), avg_degree=$(case.avg_degree)" begin
+        model = _scale_timed(
+            "construct n=$(case.n)",
+            case.construction_seconds,
+            case.construction_mib,
+        ) do
+            _scale_sparse_er_model(case.n; avg_degree = case.avg_degree, seed = 1000 + case.n)
+        end
+
+        @test QUBOTools.dimension(model) == case.n
+        @test QUBOTools.quadratic_size(model) == (case.n * case.avg_degree) ÷ 2
+
+        states = _scale_random_states(case.n, 3; seed = 2000 + case.n)
+
+        _scale_timed("evaluate n=$(case.n)", case.evaluation_seconds, case.evaluation_mib) do
+            for state in states
+                QUBOTools.value(model, state)
+            end
+        end
+
+        _scale_test_form_correctness(model, states; include_dense = case.n <= 1_000)
+        _scale_test_sampleset(model, states)
+
+        qubin_model = _scale_timed(
+            "QUBin round-trip n=$(case.n)",
+            case.qubin_seconds,
+            case.qubin_mib,
+        ) do
+            _scale_roundtrip(model, "qb")
+        end
+        _scale_assert_same_model(model, qubin_model; exact = true)
+        _scale_assert_value_preserved(model, qubin_model, states)
+
+        if case.n >= 20_000
+            qubo_model = _scale_timed(
+                "QUBO round-trip n=$(case.n)",
+                case.qubo_seconds,
+                case.qubo_mib,
+            ) do
+                _scale_roundtrip(model, "qubo")
+            end
+            _scale_assert_same_model(model, qubo_model; exact = true)
+            _scale_assert_value_preserved(model, qubo_model, states)
+        end
+    end
+
+    return nothing
+end
+
+function _scale_test_numerical_range()
+    @testset "numerical range" begin
+        model = _scale_portfolio_like_model()
+        states = _scale_random_states(QUBOTools.dimension(model), 4; seed = 90)
+
+        for suffix in ("qb", "qubo")
+            dst = _scale_roundtrip(model, suffix)
+
+            _scale_assert_same_model(model, dst; exact = true)
+            _scale_assert_value_preserved(model, dst, states)
+        end
+    end
+
+    return nothing
+end
+
+function test_scale()
+    cases = _scale_cases()
+
+    @testset "△ Scale Tests" verbose = true begin
+        @test !isempty(cases)
+
+        _scale_warmup()
+        _scale_test_synthesis_generators()
+
+        for case in cases
+            _scale_test_case(case)
+        end
+
+        _scale_test_numerical_range()
+    end
+
+    return nothing
+end

--- a/test/scale/scale.jl
+++ b/test/scale/scale.jl
@@ -105,6 +105,7 @@ function _scale_timed(f::Function, label::AbstractString, seconds::Real, mib::Re
     result = @timed f()
 
     @info label time = result.time mib = result.bytes / 2.0^20
+    # Time ceilings are coarse regression guards; allocation ceilings are the primary signal.
     @test result.time <= seconds
     @test result.bytes <= mib * 2.0^20
 
@@ -235,7 +236,7 @@ function _scale_test_synthesis_generators()
 
         for (label, problem, seconds, mib) in generators
             model = _scale_timed(label, seconds, mib) do
-                @test_logs (:warn, r"Depraction Warning") QUBOTools.generate(
+                @test_logs (:warn, r"please refer to .QUBOLib") QUBOTools.generate(
                     Random.MersenneTwister(3000),
                     problem,
                 )

--- a/test/unit/library/formats.jl
+++ b/test/unit/library/formats.jl
@@ -22,6 +22,9 @@ function test_format_hints()
         @test QUBOTools.infer_format([:qubo]) isa QUBOTools.Format{:qubo}
         @test QUBOTools.infer_format(; path = "file.qubo") isa QUBOTools.Format{:qubo}
 
+        @test QUBOTools.infer_format([:rudy]) isa QUBOTools.Format{:rudy}
+        @test QUBOTools.infer_format(; path = "file.rudy") isa QUBOTools.Format{:rudy}
+
         @test QUBOTools.infer_format([:mzn]) isa QUBOTools.Format{:minizinc}
         @test QUBOTools.infer_format(; path = "file.mzn") isa QUBOTools.Format{:minizinc}
 
@@ -83,6 +86,28 @@ function test_bqpjson_format()
 
                     @test _compare_models(src_model, dst_model)
                 end
+            end
+        end
+
+        @testset "scientific notation" begin
+            model = QUBOTools.Model{Int,Float64,Int}(
+                Set{Int}(1:3),
+                Dict{Int,Float64}(1 => 1.0e-3, 2 => -2.5e10),
+                Dict{Tuple{Int,Int},Float64}((1, 2) => -3.195264750619755e-5);
+                offset = 4.25e8,
+                sense = :min,
+                domain = :bool,
+                metadata = Dict{String,Any}("source" => "scientific-notation-test"),
+            )
+
+            _with_temp_path("bool.qubo") do temp_path
+                QUBOTools.write_model(temp_path, model)
+
+                dst_model = QUBOTools.read_model(temp_path)
+
+                @test _compare_models(model, dst_model)
+                @test QUBOTools.value(model, [1, 1, 0]) ==
+                      QUBOTools.value(dst_model, [1, 1, 0])
             end
         end
     end
@@ -311,7 +336,37 @@ end
 
 function test_rudy_format()
     @testset "⋅ Rudy" begin
-        
+        @testset "read" begin
+            file_path = _test_data_path(5, "spin.rudy")
+            model = QUBOTools.read_model(file_path)
+
+            @test model isa QUBOTools.Model
+            @test QUBOTools.dimension(model) == 10
+            @test QUBOTools.linear_size(model) == 10
+            @test QUBOTools.quadratic_size(model) == 5
+            @test QUBOTools.offset(model) == 66363.47
+            @test haskey(QUBOTools.metadata(model), "timestamp")
+        end
+
+        @testset "write/read round-trip" begin
+            model = QUBOTools.Model{Int,Float64,Int}(
+                Set{Int}(1:4),
+                Dict{Int,Float64}(1 => -1.5, 3 => 2.25),
+                Dict{Tuple{Int,Int},Float64}((1, 2) => 4.0, (2, 4) => -7.5);
+                offset = 3.5,
+                sense = :min,
+                domain = :spin,
+            )
+            fmt = QUBOTools.Format{:rudy}(; domain = :spin)
+
+            _with_temp_path("spin.rudy") do temp_path
+                QUBOTools.write_model(temp_path, model, fmt)
+
+                dst_model = QUBOTools.read_model(temp_path, fmt)
+
+                @test _compare_models(model, dst_model)
+            end
+        end
     end
 
     return nothing

--- a/test/unit/library/formats.jl
+++ b/test/unit/library/formats.jl
@@ -367,6 +367,28 @@ function test_rudy_format()
                 @test _compare_models(model, dst_model)
             end
         end
+
+        @testset "scientific notation write/read round-trip" begin
+            model = QUBOTools.Model{Int,Float64,Int}(
+                Set{Int}(1:3),
+                Dict{Int,Float64}(1 => 1.0e-5, 2 => -2.5e10),
+                Dict{Tuple{Int,Int},Float64}((1, 3) => 3.195264750619755e-5);
+                offset = 4.25e8,
+                sense = :min,
+                domain = :spin,
+            )
+            fmt = QUBOTools.Format{:rudy}(; domain = :spin)
+
+            _with_temp_path("spin.rudy") do temp_path
+                QUBOTools.write_model(temp_path, model, fmt)
+
+                dst_model = QUBOTools.read_model(temp_path, fmt)
+
+                @test _compare_models(model, dst_model)
+                @test QUBOTools.value(model, [1, -1, 1]) ==
+                      QUBOTools.value(dst_model, [1, -1, 1])
+            end
+        end
     end
 
     return nothing


### PR DESCRIPTION
Summary
- Adds an opt-in scale-test tier gated by `QUBOTOOLS_SCALE_TESTS`, with `scale-only` support and a scheduled GitHub Actions workflow.
- Covers sparse generated cases through 100000 variables, SK/Wishart synthesis smoke cases, value cross-checks, QUBin/QUBO round-trips, numerical-range preservation, and large-state `SampleSet` handling.
- Fixes sparse form copying so sparse-to-sparse conversion does not allocate a dense `n x n` matrix.
- Makes QUBO parsing accept scientific-notation coefficients and adds Rudy write/read coverage.
- Adds a Scalability docs page describing the tested envelope and sparse/dense memory expectations.

Tests
- Posted pre-test baseline data on issue #100: https://github.com/JuliaQUBO/QUBOTools.jl/issues/100#issuecomment-4735449582
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` passed: 1122 tests.
- `env QUBOTOOLS_SCALE_TESTS=true QUBOTOOLS_SCALE_MAX_N=100000 julia +1.12 --project=. -e 'using Pkg; Pkg.test(; test_args = ["scale-only"])'` passed: 176 tests.
- `env QUBOTOOLS_DOCS_SKIP_PLOTS=true julia --project=docs docs/make.jl --skip-deploy` passed.

Notes
- `julia +1.12 --project=docs docs/make.jl --skip-deploy` fails in this local checkout because `docs/Manifest.toml` was resolved with Julia 1.10 and the local depot is missing `MbedTLS_jll` source metadata for the Julia 1.12 docs environment. The docs build passes with Julia 1.10 and plot rendering skipped, matching the docs test path.

Branch Hygiene
- Base branch: `main`
- Source branch: `fix/issue-100-scale-tests`
- Source branch point: `origin/main` at `8a4caac0d825f28aecb633484aaa4ee2a56a6b6a`
- Stacked status: not stacked
- Prerequisite PRs: none. Related blocker #101 is already resolved by merged PR #103.

Closes #100
