### PR TITLE
Fix generate deprecation warning typo

### DIFF
--- a/src/library/synthesis/abstract.jl
+++ b/src/library/synthesis/abstract.jl
@@ -3,5 +3,5 @@ function generate(problem::AbstractProblem)
 end
 
 macro _deprecate_generate()
-    return quote @warn("Depraction Warning: To use `generate`, please refer to `QUBOLib.jl`") end
+    return quote @warn("Deprecation Warning: To use `generate`, please refer to `QUBOLib.jl`") end
 end

--- a/test/unit/library/synthesis.jl
+++ b/test/unit/library/synthesis.jl
@@ -12,7 +12,9 @@ function test_wishart()
         let n = 100
             m = 10
 
-            model = QUBOTools.generate(QUBOTools.Wishart(n, m))
+            model = @test_logs (:warn, r"Deprecation Warning:.*QUBOLib") QUBOTools.generate(
+                QUBOTools.Wishart(n, m),
+            )
 
             @test QUBOTools.dimension(model) == n
             @test QUBOTools.density(model) ≈ 1.0 atol = 1E-8
@@ -32,7 +34,9 @@ function test_sherrington_kirkpatrick()
             μ = 5.0
             σ = 1E-3
         
-            model = QUBOTools.generate(QUBOTools.SK(n, μ, σ))
+            model = @test_logs (:warn, r"Deprecation Warning:.*QUBOLib") QUBOTools.generate(
+                QUBOTools.SK(n, μ, σ),
+            )
             
             @test QUBOTools.dimension(model) == n
             @test QUBOTools.density(model) ≈ 1.0 atol = 1E-8


### PR DESCRIPTION
## Summary
- Fix the misspelled `Depraction Warning` text emitted by deprecated synthesis `generate` calls.
- Add synthesis unit assertions for the corrected warning text.

## Tests
- `git diff --check`
- `julia +1.12 --project=. -e 'using Test, Statistics, QUBOTools; include("test/unit/library/synthesis.jl"); test_synthesis()'`
- `QUBOTOOLS_SCALE_TESTS=true QUBOTOOLS_SCALE_MAX_N=1000 julia +1.12 --project=. test/scale/runtests.jl`
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
