### PR TITLE
Speed up MOI backend extraction

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -31,6 +31,34 @@ exercises the same public MOI extraction path used by ToQUBO integrations:
 QUBOTools.Model(moi_model)
 ```
 
+Profiling this path should be interpreted as QUBOTools backend
+materialization, not JuMP model construction or optimization. For dense TSP
+fixtures the dominant work is linear in the number of MOI quadratic terms:
+copying MOI terms into sparse triplet buffers, then converting those buffers to
+the package sparse CSC representation with `SparseArrays.sparse`.
+
+To reproduce the larger 10,000-variable extraction shape directly, run:
+
+```bash
+julia --project=benchmark -e '
+import Pkg
+Pkg.develop(; path = pwd())
+Pkg.instantiate()
+
+using Random
+using SparseArrays
+using BenchmarkTools
+using MathOptInterface
+using QUBOTools
+
+include("benchmark/suites/fixtures.jl")
+
+fixture = benchmark_dense_tsp_constructor_fixture("tsp/cities=100", 100)
+
+display(@benchmark QUBOTools.Model($(fixture.bool_moi_model)) samples = 10 evals = 1)
+'
+```
+
 The default fixture is sized for pull-request benchmark runtime. To add the
 10,000-variable TSP extraction case (`tsp/cities=100`) to the constructor suite,
 set `QUBOTOOLS_SCALE_BENCHMARKS=true` when running the benchmark commands.

--- a/ext/QUBOTools_MOI/model_parser.jl
+++ b/ext/QUBOTools_MOI/model_parser.jl
@@ -151,14 +151,63 @@ function _remaining_variable_map(variables::AbstractVector{VI}, fixed::Dict{VI,T
     end
 end
 
+# Avoid huge lookup vectors for MOI backends with sparse variable ids.
+const _DENSE_VARIABLE_LOOKUP_MAX_FACTOR = 4
+
+function _variable_index_lookup(variable_map::QUBOTools.VariableMap{VI})
+    n = length(variable_map)
+
+    iszero(n) && return Int[]
+
+    max_value = 0
+
+    for vi in variable_map.inv
+        value = vi.value
+
+        value > 0 || return variable_map.map
+
+        max_value = max(max_value, value)
+    end
+
+    max_value <= _DENSE_VARIABLE_LOOKUP_MAX_FACTOR * n || return variable_map.map
+
+    lookup = zeros(Int, max_value)
+
+    for (i, vi) in enumerate(variable_map.inv)
+        @inbounds lookup[vi.value] = i
+    end
+
+    return lookup
+end
+
+@inline function _variable_index(variable_index::Dict{VI,Int}, xi::VI)
+    return variable_index[xi]
+end
+
+@inline function _variable_index(variable_index::Vector{Int}, xi::VI)
+    value = xi.value
+
+    @boundscheck begin
+        1 <= value <= length(variable_index) || throw(KeyError(xi))
+    end
+
+    i = @inbounds variable_index[value]
+
+    @boundscheck begin
+        !iszero(i) || throw(KeyError(xi))
+    end
+
+    return i
+end
+
 function _append_linear_term!(
     linear_indices::Vector{Int},
     linear_values::Vector{T},
-    variable_index::Dict{VI,Int},
+    variable_index,
     xi::VI,
     ci,
 ) where {T}
-    push!(linear_indices, variable_index[xi])
+    push!(linear_indices, _variable_index(variable_index, xi))
     push!(linear_values, ci)
 
     return nothing
@@ -168,13 +217,13 @@ function _append_quadratic_term!(
     quadratic_rows::Vector{Int},
     quadratic_cols::Vector{Int},
     quadratic_values::Vector{T},
-    variable_index::Dict{VI,Int},
+    variable_index,
     xi::VI,
     xj::VI,
     cij,
 ) where {T}
-    i = variable_index[xi]
-    j = variable_index[xj]
+    i = _variable_index(variable_index, xi)
+    j = _variable_index(variable_index, xj)
 
     if i < j
         push!(quadratic_rows, i)
@@ -192,7 +241,7 @@ end
 function _add_linear_or_offset!(
     linear_indices::Vector{Int},
     linear_values::Vector{T},
-    variable_index::Dict{VI,Int},
+    variable_index,
     fixed::Dict{VI,T},
     β::T,
     xi::VI,
@@ -247,7 +296,7 @@ function _extract_bool_model(
     fixed::Dict{VI,T},
 ) where {T}
     variable_map = _remaining_variable_map(variables, fixed)
-    variable_index = variable_map.map
+    variable_index = _variable_index_lookup(variable_map)
 
     F = MOI.get(model, MOI.ObjectiveFunctionType())
     f = MOI.get(model, MOI.ObjectiveFunction{F}())
@@ -386,7 +435,7 @@ function _extract_spin_model(
     fixed::Dict{VI,T},
 ) where {T}
     variable_map = _remaining_variable_map(variables, fixed)
-    variable_index = variable_map.map
+    variable_index = _variable_index_lookup(variable_map)
 
     F = MOI.get(model, MOI.ObjectiveFunctionType())
     f = MOI.get(model, MOI.ObjectiveFunction{F}())

--- a/ext/QUBOTools_MOI/model_parser.jl
+++ b/ext/QUBOTools_MOI/model_parser.jl
@@ -187,14 +187,14 @@ end
 @inline function _variable_index(variable_index::Vector{Int}, xi::VI)
     value = xi.value
 
-    @boundscheck begin
-        1 <= value <= length(variable_index) || throw(KeyError(xi))
+    if !(1 <= value <= length(variable_index))
+        throw(KeyError(xi))
     end
 
     i = @inbounds variable_index[value]
 
-    @boundscheck begin
-        !iszero(i) || throw(KeyError(xi))
+    if iszero(i)
+        throw(KeyError(xi))
     end
 
     return i

--- a/test/integration/ext/moi.jl
+++ b/test/integration/ext/moi.jl
@@ -25,6 +25,29 @@ function test_moi_variables()
             @test QUBOTools.varshow(VI(103)) == "x₁₀₃"
             @test QUBOTools.varshow(VI(-13)) == "x₋₁₃"
         end
+
+        @testset "→ variable index lookup" begin
+            compact_map = QUBOTools.VariableMap{VI}([VI(1), VI(2), VI(3)])
+            compact_lookup = QUBOTools_MOI._variable_index_lookup(compact_map)
+
+            @test compact_lookup isa Vector{Int}
+            @test QUBOTools_MOI._variable_index(compact_lookup, VI(2)) == 2
+
+            sparse_map = QUBOTools.VariableMap{VI}([VI(1), VI(10)])
+            sparse_lookup = QUBOTools_MOI._variable_index_lookup(sparse_map)
+
+            @test sparse_lookup isa Dict{VI,Int}
+            @test QUBOTools_MOI._variable_index(sparse_lookup, VI(10)) == 2
+
+            non_positive_map = QUBOTools.VariableMap{VI}([VI(1), VI(-1)])
+            non_positive_lookup = QUBOTools_MOI._variable_index_lookup(non_positive_map)
+
+            @test non_positive_lookup isa Dict{VI,Int}
+            @test QUBOTools_MOI._variable_index(non_positive_lookup, VI(-1)) == 2
+
+            @test_throws KeyError QUBOTools_MOI._variable_index(compact_lookup, VI(4))
+            @test_throws KeyError QUBOTools_MOI._variable_index([1, 0, 2], VI(2))
+        end
     end
 
     return nothing
@@ -152,6 +175,40 @@ function test_moi_bool_model_parser()
                     @test α ≈ 1.0
                     @test β ≈ 12.9
                 end
+            end
+        end
+
+        @testset "⋅ Sparse Remaining Variable IDs" begin
+            moi_model = MOI.Utilities.Model{Float64}()
+
+            v = MOI.add_variables(moi_model, 10)
+
+            MOI.set(
+                moi_model,
+                MOI.ObjectiveFunction{SQF{Float64}}(),
+                SQF{Float64}(
+                    SQT{Float64}[SQT{Float64}(12.0, v[1], v[10])],
+                    SAT{Float64}[SAT{Float64}(2.0, v[1]), SAT{Float64}(4.0, v[10])],
+                    1.5,
+                ),
+            )
+
+            MOI.set(moi_model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+            MOI.add_constraints(moi_model, v, fill(MOI.ZeroOne(), 10))
+            MOI.add_constraints(moi_model, v[2:9], MOI.EqualTo{Float64}.(zeros(8)))
+
+            let qt_model = QUBOTools.Model{Float64}(moi_model)
+                n, L, Q, α, β, s, X = QUBOTools.qubo(qt_model, :dense)
+
+                @test n == 2
+                @test s == QUBOTools.sense(:min)
+                @test X == QUBOTools.domain(:bool)
+                @test L == [2.0, 4.0]
+                @test Q == [0.0 12.0; 0.0 0.0]
+                @test α ≈ 1.0
+                @test β ≈ 1.5
+                @test QUBOTools.variable(qt_model, 1) == v[1]
+                @test QUBOTools.variable(qt_model, 2) == v[10]
             end
         end
     end


### PR DESCRIPTION
## Summary

- Optimizes MOI backend extraction by using a dense integer lookup vector when MOI variable ids are compact, avoiding two dictionary lookups per quadratic term in the dense ToQUBO-style path.
- Keeps the dictionary fallback for sparse or non-positive MOI variable ids so generic MOI backends keep existing behavior.
- Documents the dense TSP extraction cost center and adds a focused 10,000-variable reproduction command to `benchmark/README.md`.

Refs #107.

## Profiling Notes

For the `benchmark_dense_tsp_constructor_fixture("tsp/cities=100", 100)` shape:

- variables: 10,000
- quadratic terms: 1,980,000
- before this change: `Trial(117.953 ms)`, `144230184` bytes allocated
- after this change: `Trial(78.398 ms)`, `144310232` bytes allocated

The remaining dominant cost is expected sparse materialization work: copying MOI quadratic terms into sparse triplet buffers and building the CSC matrix with `SparseArrays.sparse`.

## Tests

- `JULIA_DEPOT_PATH=/tmp/qubotools-julia-depot-112:/home/bernalde/.julia /home/bernalde/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia --project=test --startup-file=no -e 'import Pkg; Pkg.develop(; path=pwd()); Pkg.instantiate(); include("test/runtests.jl")'`
  - Passed: 1124 tests.
- `JULIA_DEPOT_PATH=/tmp/qubotools-julia-depot-112:/home/bernalde/.julia JULIA_LOAD_PATH=@:/home/bernalde/repos/QUBOTools.jl:@stdlib /home/bernalde/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia --project=test --startup-file=no -e 'using Test; using QUBOTools; using MathOptInterface; const MOI = MathOptInterface; const MOIU = MOI.Utilities; const VI = MOI.VariableIndex; const SAF{T} = MOI.ScalarAffineFunction{T}; const SAT{T} = MOI.ScalarAffineTerm{T}; const SQF{T} = MOI.ScalarQuadraticFunction{T}; const SQT{T} = MOI.ScalarQuadraticTerm{T}; const QUBOTools_MOI = Base.get_extension(QUBOTools, :QUBOTools_MOI); const Spin = QUBOTools_MOI.Spin; const QUBOModel = QUBOTools_MOI.QUBOModel; const NumberOfReads = QUBOTools_MOI.NumberOfReads; include("test/integration/ext/moi.jl"); test_moi()'`
  - Passed: 67 tests.
- `JULIA_DEPOT_PATH=/tmp/qubotools-julia-depot:/home/bernalde/.julia /home/bernalde/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/bin/julia --project=benchmark --startup-file=no benchmark/test/runtests.jl`
  - Passed: 17 benchmark fixture tests and 8 benchmark suite tests.
- `JULIA_DEPOT_PATH=/tmp/qubotools-julia-depot:/home/bernalde/.julia /home/bernalde/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/bin/julia --project=benchmark --startup-file=no -e 'using Random, SparseArrays, QUBOTools, MathOptInterface, BenchmarkTools; include("benchmark/suites/fixtures.jl"); fixture = benchmark_dense_tsp_constructor_fixture("tsp/cities=100", 100); model = QUBOTools.Model(fixture.bool_moi_model); allocated = @allocated QUBOTools.Model(fixture.bool_moi_model); trial = @benchmark QUBOTools.Model($(fixture.bool_moi_model)) samples=10 evals=1; println("cities=", fixture.cities); println("variables=", fixture.cities^2); println("linear=", length(fixture.linear)); println("quadratic=", length(fixture.quadratic)); println("allocated=", allocated); println("trial=", trial)'`
  - Result: `Trial(78.398 ms)`, `144310232` bytes allocated.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `7751280aaaa8065050bb1dcdd4dbc741505cc313`
- Stacked status: not stacked
- Prerequisite PRs: none

