### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # QUBOTools.jl Changelog
 
-## Unreleased
+## v0.15.0 (2026-06-24)
 
 ### Breaking Changes
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBOTools"
 uuid = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.14.4"
+version = "0.15.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ Release changes live in this repository first. The release preflight checks the 
 
 1. Update `Project.toml` to the target version.
 2. Add a `CHANGELOG.md` section for `vX.Y.Z`.
-3. Update `docs/Project.toml` self-compat for `QUBOTools` so it includes the target release line.
+3. Update `docs/Project.toml` and `benchmark/Project.toml` self-compat for `QUBOTools` so each includes the target release line.
    - For `0.Y.Z`, include `0.Y`.
    - For `0.0.Z`, include `0.0.Z`.
    - For `X.Y.Z` with `X > 0`, include `X`.

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -11,6 +11,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 BenchmarkTools = "1"
 MathOptInterface = "1"
-QUBOTools = "0.12.1, 0.13, 0.14"
+QUBOTools = "0.12.1, 0.13, 0.14, 0.15"
 Tar = "1.9.2"
 julia = "1.10"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,4 +6,4 @@ QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 [compat]
 Documenter = "1"
 Plots = "~1.38, 1.41"
-QUBOTools = "0.12.1, 0.13, 0.14"
+QUBOTools = "0.12.1, 0.13, 0.14, 0.15"

--- a/scripts/release_check.jl
+++ b/scripts/release_check.jl
@@ -51,46 +51,76 @@ function release_section(changelog::String, version::VersionNumber)
     return join(lines[start:stop], "\n")
 end
 
+function check_self_compat!(
+    failures::Vector{String},
+    project::Dict{String,Any},
+    env_project::Dict{String,Any},
+    env_name::AbstractString,
+    expected_self_compat::AbstractString,
+    version::VersionNumber,
+)
+    env_deps = env_project["deps"]
+    env_compat = env_project["compat"]
+    env_self_compat = get(env_compat, "QUBOTools", nothing)
+
+    check!(
+        failures,
+        get(env_deps, "QUBOTools", nothing) == project["uuid"],
+        "$env_name/Project.toml must depend on this package UUID for QUBOTools.",
+    )
+    check!(
+        failures,
+        env_self_compat !== nothing,
+        "$env_name/Project.toml must declare QUBOTools compat.",
+    )
+
+    if env_self_compat !== nothing
+        check!(
+            failures,
+            expected_self_compat in compat_entries(env_self_compat),
+            "$env_name/Project.toml compat for QUBOTools must include \"$expected_self_compat\" for version $version.",
+        )
+        check!(
+            failures,
+            compat_allows(env_self_compat, version),
+            "$env_name/Project.toml compat for QUBOTools must allow version $version.",
+        )
+    end
+
+    return nothing
+end
+
 function main()
     failures = String[]
     warnings = String[]
 
     project = read_toml("Project.toml")
     docs_project = read_toml("docs", "Project.toml")
+    benchmark_project = read_toml("benchmark", "Project.toml")
 
     version = VersionNumber(project["version"])
     expected_self_compat = release_line_compat(version)
 
     check!(failures, project["name"] == "QUBOTools", "Project.toml name is not QUBOTools.")
 
-    docs_deps = docs_project["deps"]
-    docs_compat = docs_project["compat"]
     project_compat = project["compat"]
-    docs_self_compat = get(docs_compat, "QUBOTools", nothing)
 
-    check!(
+    check_self_compat!(
         failures,
-        get(docs_deps, "QUBOTools", nothing) == project["uuid"],
-        "docs/Project.toml must depend on this package UUID for QUBOTools.",
+        project,
+        docs_project,
+        "docs",
+        expected_self_compat,
+        version,
     )
-    check!(
+    check_self_compat!(
         failures,
-        docs_self_compat !== nothing,
-        "docs/Project.toml must declare QUBOTools compat.",
+        project,
+        benchmark_project,
+        "benchmark",
+        expected_self_compat,
+        version,
     )
-
-    if docs_self_compat !== nothing
-        check!(
-            failures,
-            expected_self_compat in compat_entries(docs_self_compat),
-            "docs/Project.toml compat for QUBOTools must include \"$expected_self_compat\" for version $version.",
-        )
-        check!(
-            failures,
-            compat_allows(docs_self_compat, version),
-            "docs/Project.toml compat for QUBOTools must allow version $version.",
-        )
-    end
 
     check!(
         failures,


### PR DESCRIPTION
## Summary

- Bump QUBOTools to `v0.15.0`.
- Move the changelog entry for stricter BQPJSON `metadata.synthesis` validation into the `v0.15.0` section.
- Extend docs self-compat to include the `0.15` release line.

## Release Notes

### Breaking changes

- BQPJSON files with `metadata.synthesis` now must use a synthesis object with a `model` string and a `parameters` object. Wishart synthesis metadata requires integer `n` and `m` parameters.

## Checks

- `julia +1.12 --project=. scripts/release_check.jl` passed.
- `julia +1.12 --project=. -e 'import Pkg; Pkg.test()'` passed, 1157/1157 tests.
- `julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'` passed.
- `julia +1.12 --project=docs docs/make.jl --skip-deploy` passed.
