### PR TITLE
Release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # QUBOTools.jl Changelog
 
+## v0.15.1 (2026-06-24)
+
+### Compatibility
+
+- Allow PseudoBooleanOptimization 0.3 releases.
+
 ## v0.15.0 (2026-06-24)
 
 ### Breaking Changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBOTools"
 uuid = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.15.0"
+version = "0.15.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
## Summary
- Bump QUBOTools to v0.15.1.
- Add a changelog entry for the PseudoBooleanOptimization 0.3 compat widening.

## Validation
- `julia --project=. scripts/release_check.jl`
- `julia +1.12 --project=. -e 'import Pkg; Pkg.test()'` (1157/1157 tests passed)
- `julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`
- `julia +1.12 --project=docs docs/make.jl --skip-deploy`
- Fresh Julia 1.10 depot resolves local QUBOTools v0.15.1 with PseudoBooleanOptimization v0.3.0 and imports both.

Note: the documented Julia 1.10 package-test command fails locally before tests because the checked-in Manifest.toml was generated with Julia 1.12.0; CI covers the Julia 1.10 floor.