### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # QUBOTools.jl Changelog
 
+## v0.16.0 (2026-06-25)
+
+### Changelog
+
+- Add public sparse `QUBOTools.Model` constructors from indexed variable
+  vectors plus COO triples or prebuilt sparse forms, documenting
+  upper-triangular normalization, duplicate summation, zero dropping,
+  scale/offset semantics, and variable-index mapping.
+
 ## v0.15.1 (2026-06-24)
 
 ### Compatibility

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBOTools"
 uuid = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.15.1"
+version = "0.16.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -11,6 +11,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 BenchmarkTools = "1"
 MathOptInterface = "1"
-QUBOTools = "0.12.1, 0.13, 0.14, 0.15"
+QUBOTools = "0.12.1, 0.13, 0.14, 0.15, 0.16"
 Tar = "1.9.2"
 julia = "1.10"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,4 +6,4 @@ QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 [compat]
 Documenter = "1"
 Plots = "~1.38, 1.41"
-QUBOTools = "0.12.1, 0.13, 0.14, 0.15"
+QUBOTools = "0.12.1, 0.13, 0.14, 0.15, 0.16"


### PR DESCRIPTION
Summary
- Bump QUBOTools to v0.16.0.
- Add changelog entry for sparse Model constructors.
- Extend docs and benchmark self-compat to 0.16.

Checks
- julia +1.12 --project=. scripts/release_check.jl
- julia +1.12 --project=. -e 'import Pkg; Pkg.test()'
- julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'
- julia +1.12 --project=docs docs/make.jl --skip-deploy