### PR TITLE
Audit Documenter missing-docstring warnings

### DIFF
--- a/docs/build.jl
+++ b/docs/build.jl
@@ -65,7 +65,7 @@ function build_docs(; deploy::Bool = false)
                     docs_repository_ref(DOCS_REPOSITORY_ROOT),
                 ),
             ),
-            warnonly = [:missing_docs, :docs_block],
+            warnonly = [:docs_block],
             pages    = DOCS_PAGES,
             format   = Documenter.HTML(
                 assets           = ["assets/extra_styles.css", "assets/favicon.ico"],

--- a/docs/build.jl
+++ b/docs/build.jl
@@ -49,7 +49,9 @@ function build_docs(; deploy::Bool = false)
     # Keep Plots on a non-interactive backend only while Documenter runs.
     withenv("GKSwstype" => "100") do
         makedocs(;
-            modules  = [QUBOTools, QUBOTools.PBO],
+            # Check QUBOTools' public docs surface. QUBOTools.PBO is a dependency
+            # namespace re-export and is documented upstream rather than here.
+            modules  = [QUBOTools],
             doctest  = true,
             clean    = true,
             sitename = "QUBOTools.jl",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -36,7 +36,7 @@ QUBOTools.VariableMap
 ```
 
 ```@docs
-QUBOTools.PBO.varlt
+QUBOTools.varlt
 ```
 
 ## Objective & Domain Frames
@@ -191,8 +191,10 @@ QUBOTools.attach!
 
 ```@docs
 QUBOTools.AbstractFormat
+QUBOTools.Format
 QUBOTools.format
 QUBOTools.version
+QUBOTools.infer_format
 ```
 
 ```@docs
@@ -211,6 +213,7 @@ QUBOTools.write_samples
 
 ```@docs
 QUBOTools.FormatError
+QUBOTools.FormatInferenceError
 QUBOTools.SyntaxError
 ```
 

--- a/src/QUBOTools.jl
+++ b/src/QUBOTools.jl
@@ -19,6 +19,14 @@ using Random
 import PseudoBooleanOptimization as PBO
 import PseudoBooleanOptimization: varlt, varshow
 
+@doc raw"""
+    varlt(x, y)
+
+Return `true` when variable `x` should sort before variable `y` in QUBOTools'
+canonical variable ordering.
+"""
+varlt
+
 const __PROJECT__ = Ref{Union{String,Nothing}}(nothing)
 
 function __project__()

--- a/src/interface/format.jl
+++ b/src/interface/format.jl
@@ -1,11 +1,15 @@
 @doc raw"""
     AbstractFormat
 
+Supertype for QUBOTools file-format descriptors used by model and solution I/O.
 """
 abstract type AbstractFormat end
 
 @doc raw"""
     Format{F}
+
+Concrete format descriptor for format `F`, storing validated format-specific
+settings.
 """
 struct Format{F} <: AbstractFormat
     settings::Dict{Symbol,Any}
@@ -34,6 +38,9 @@ function format end
 
 @doc raw"""
     FormatInferenceError
+
+Thrown when QUBOTools cannot infer a supported format from a path or hint
+sequence.
 """
 struct FormatInferenceError{S} <: Exception
     source::S
@@ -55,7 +62,11 @@ function format_inference_error(source)
 end
 
 @doc raw"""
+    infer_format(hints::Vector{Symbol})::Format
     infer_format(; path::AbstractString)
+
+Infer a QUBOTools file format from ordered hint symbols or from the suffixes of
+`path`.
 """
 function infer_format end
 


### PR DESCRIPTION
## Summary

- Restrict Documenter's missing-docstring checks to QUBOTools' own public documentation surface.
- Document the direct QUBOTools format-inference API entries that were previously missing from `docs/src/api.md`.
- Replace the dependency-qualified `QUBOTools.PBO.varlt` API entry with the QUBOTools binding and add a short QUBOTools-specific docstring.

Closes #118

## Tests

- `julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`
  - Passed; no packages added to or removed from `docs/Project.toml` or `docs/Manifest.toml`.
- `julia +1.12 --project=docs docs/make.jl --skip-deploy`
  - Passed; the 42-item missing-docstring warning is gone.
  - The pre-existing large HTML representation warning remains for four `manual/7-analysis.md` examples.
- `julia +1.12 --project=. -e 'import Pkg; Pkg.test()'`
  - Passed: 1175/1175 tests.
  - Julia emitted pre-existing test-manifest mismatch warnings while constructing the temporary test environment.

## Branch Hygiene

- Base branch: `main`
- Source branch: `fix/issue-118-docstring-audit`
- Source branch point: `origin/main` at `6a67d396a9887335ba7c887f98b8dde68a357aa9`
- Stacked status: not stacked
- Prerequisite PRs: none
