### PR TITLE
Release QUBOTools v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # QUBOTools.jl Changelog
 
+## v0.16.1 (2026-07-21)
+
+### Documentation
+
+- Complete the documented public API surface for format inference and canonical
+  variable ordering, and limit missing-docstring checks to QUBOTools' own
+  public bindings.
+
+### CI
+
+- Update the checkout, Python setup, and Codecov GitHub Actions.
+
 ## v0.16.0 (2026-06-25)
 
 ### Changelog

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBOTools"
 uuid = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.16.0"
+version = "0.16.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
## Summary

- Bump QUBOTools from v0.16.0 to v0.16.1.
- Document the public API/docstring work merged in #119.
- Record the GitHub Actions maintenance merged in #121, #122, and #123.
- Keep the existing docs and benchmark self-compat entries, which already cover the 0.16 release line.

## Tests

- `julia +1.12 --project=. scripts/release_check.jl`
  - Passed for QUBOTools v0.16.1.
- `julia +1.12 --project=. -e 'import Pkg; Pkg.test()'`
  - Passed: 1175/1175 tests.
- `julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`
  - Passed.
- `julia +1.12 --project=docs docs/make.jl --skip-deploy`
  - Passed.
  - Documenter retained the pre-existing large HTML representation warning for four examples on `manual/7-analysis.md`; SVG fallbacks were generated.
