### PR TITLE
Add published QUBO.jl article badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
     <a href="https://arxiv.org/abs/2307.02577">
         <img src="https://img.shields.io/badge/arXiv-2307.02577-b31b1b.svg" alt="arXiv"/>
     </a>
+    <a href="https://doi.org/10.1080/10556788.2026.2702926">
+        <img src="https://img.shields.io/badge/DOI-10.1080%2F10556788.2026.2702926-blue.svg" alt="Journal article DOI"/>
+    </a>
     <a href="https://codecov.io/gh/JuliaQUBO/QUBOTools.jl" > 
         <img src="https://codecov.io/gh/JuliaQUBO/QUBOTools.jl/branch/main/graph/badge.svg?token=W7QJWS5HI4"/> 
     </a>


### PR DESCRIPTION
## Summary

Add a journal DOI badge for the published QUBO.jl ecosystem paper beside the existing arXiv badge. The arXiv preprint link remains unchanged.

Closes #125

## Maintainer Triage

- Change type:
  - [ ] Bug fix
  - [x] Documentation
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] Maintenance
- Docs-only:
  - [x] Yes
  - [ ] No
- Release impact:
  - [x] None
  - [ ] Patch
  - [ ] Minor
  - [ ] Blocking
- Needs design review:
  - [ ] Yes
  - [x] No

## Acceptance Criteria

- [x] The README visibly links to the published article through DOI `10.1080/10556788.2026.2702926`.
- [x] The existing arXiv `2307.02577` badge and link remain available.

## Verification

- [x] Tests updated or not needed (README-only badge change)
- [x] Documentation updated or not needed
- `git diff --check`
- Confirmed the DOI resolver redirects to the cited Taylor & Francis article.
- Confirmed the Shields.io badge endpoint returns an SVG successfully.

## Branch Hygiene

- Base: `main` at `b85cc566602ea18c0abf4667885590e33f7bb236`
- Head: `docs/issue-125-journal-article`
- Standalone PR; no prerequisite or stacked PR.
- No open PR overlaps `README.md` at branch creation.
